### PR TITLE
Puppet command

### DIFF
--- a/scripts/puppet.coffee
+++ b/scripts/puppet.coffee
@@ -1,0 +1,16 @@
+# Description:
+#   Puppet lets administrators speak through the bot.
+#
+# Dependencies:
+#   None
+#
+# Configuration:
+#   None
+#
+# Commands:
+
+module.exports = (robot) ->
+
+  robot.respond /puppet(?:\s+#(\w+))?\s+(.+)/i, (msg) ->
+    room = msg.match[1] or 'general'
+    robot.messageRoom room, msg.match[2]

--- a/scripts/puppet.coffee
+++ b/scripts/puppet.coffee
@@ -12,5 +12,7 @@
 module.exports = (robot) ->
 
   robot.respond /puppet(?:\s+#(\w+))?\s+(.+)/i, (msg) ->
+    return unless robot.auth.hasRole(msg.message.user, 'knober whisperer')
+
     room = msg.match[1] or 'general'
     robot.messageRoom room, msg.match[2]


### PR DESCRIPTION
Now that PushBot is a proper Slack user, we can reinstate the puppet command. For best results you can fire it off from a PM, where the `@pushbot:` bit isn't required.

Syntax:

 * `@pushbot: puppet some text` makes "some text" appear in **#general**.
 * `@pushbot: puppet #thechalkcircle wooo` makes "wooo" appear in **#thechalkcircle**.

Command help intentionally omitted for maximum Secrets :closed_lock_with_key:.

/cc @atiaxi 