### PR TITLE
Collapse the none/NAAN triggers together.

### DIFF
--- a/scripts/simple.coffee
+++ b/scripts/simple.coffee
@@ -127,11 +127,8 @@ module.exports = (robot) ->
         , 1000
     sendThenWait lines.shift(), lines
 
-  robot.hear /none/i, (msg) ->
-    msg.send "more like \"#{msg.message.text.replace /none/ig, 'NAAN'}\"!"
-
-  robot.hear /non-/i, (msg) ->
-    msg.send "more like \"#{msg.message.text.replace /non-/ig, "NAAN-"}\"!"
+  robot.hear /none|non-/i, (msg) ->
+    msg.send "more like \"#{msg.message.text.replace /none|non-/ig, 'NAAN'}\"!"
 
   robot.respond /(?:harm|betray)(?: (\S+))?/i, (msg) ->
     if msg.message.user.id in betrayImmune


### PR DESCRIPTION
This will prevent a bug where *both* fire when a single line contains both "none" and "non-":

```
smashwilson [12:15 PM]
@k0d3k1ttn: oh yeah, i was going to fix that bug @pusscat found with the dual none / non- triggers

pushbot [12:15 PM] 
more like "@k0d3k1ttn: oh yeah, i was going to fix that bug @pusscat found with the dual NAAN / non- triggers"!

pushbot [12:15 PM]
more like "@k0d3k1ttn: oh yeah, i was going to fix that bug @pusscat found with the dual none / NAAN- triggers"!
```