### PR TITLE
Store arbitrary user mappings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .env
 .botrc
 .hubot_history
+botdata

--- a/botrc.example
+++ b/botrc.example
@@ -31,3 +31,7 @@ export HUBOT_GREETINGS_FFA=1
 # hubot-quotefile
 
 export HUBOT_QUOTEFILE_PATH=
+
+# mapping
+
+export HUBOT_MAPPING_DATAROOT=botdata/

--- a/scripts/mapping.coffee
+++ b/scripts/mapping.coffee
@@ -49,7 +49,7 @@ class Mapping
         callback(err)
         return
 
-      callback(null, @data[username] or @missingText)
+      callback(null, @data[username.toLowerCase()] or @missingText)
 
   set: (username, value, callback) ->
     @loaded (err) =>
@@ -57,7 +57,7 @@ class Mapping
         callback(err)
         return
 
-      @data[username] = value
+      @data[username.toLowerCase()] = value
 
       @saveThen callback
 

--- a/scripts/mapping.coffee
+++ b/scripts/mapping.coffee
@@ -69,8 +69,9 @@ class Mapping
 
       ms = []
       for fileName in files
-        if fileName.indexOf('.json', file.length - 5) != -1
+        if fileName.indexOf('.json', fileName.length - 5) isnt -1
           ms.push new Mapping(fileName.substring(0, fileName.length - 5))
+      callback(null, ms)
 
 module.exports = (robot) ->
 

--- a/scripts/mapping.coffee
+++ b/scripts/mapping.coffee
@@ -25,7 +25,7 @@ class Mapping
   isLoaded: -> @data?
 
   loaded: (callback) ->
-    if @isLoaded then callback(null) else reloadThen(callback)
+    if @isLoaded() then callback(null) else @reloadThen(callback)
 
   createThen: (callback) ->
     @data = {}

--- a/scripts/mapping.coffee
+++ b/scripts/mapping.coffee
@@ -85,19 +85,20 @@ module.exports = (robot) ->
     true
 
   createMapping = (mapping) ->
-    robot.respond /#{mapping.name}(?:\s+@?(\S+))?/, (msg) ->
+    robot.respond new RegExp("#{mapping.name}(?:\\s+@?(\\S+))?", 'i'), (msg) ->
       username = msg.match[1] or msg.message.user.name
 
       mapping.get username, (err, value) ->
-        msg.reply "#{username}: #{value}"
+        msg.send "#{username}: #{value}"
 
-    robot.respond /set#{mapping.name}\s+@?(\S+)\s+(.+)/, (msg) ->
+    robot.respond new RegExp("set#{mapping.name}\\s+@?(\\S+)\\s+(.+)", 'i'), (msg) ->
       return unless checkAuth(msg)
 
       username = msg.match[1]
       value = msg.match[2]
 
       mapping.set username, value, (err) ->
+        msg.send "#{username}'s #{mapping.name} has been set to '#{value}'."
 
   # Initial load.
   Mapping.all (err, ms) ->

--- a/scripts/mapping.coffee
+++ b/scripts/mapping.coffee
@@ -1,0 +1,115 @@
+# Description:
+#   Maintain arbitrary sets of username -> text mappings.
+#
+# Commands:
+#   hubot setupmapping <mappingname> - create mapping commands and data files called <mappingname>.
+#   hubot <mappingname> <username> - show <username>'s current setting in a particular mapping.
+#   hubot set<mappingname> <username> <value> - set <username>'s current mapping to <value>.
+#
+# Configuration:
+#
+#   HUBOT_MAPPING_DATAROOT Root directory to store mapping files.
+
+fs = require 'fs'
+path = require 'path'
+
+ADMIN_ROLE = 'mapmaker'
+DATAROOT = process.env.HUBOT_MAPPING_DATAROOT or '/var/pushbot/botdata/mappings'
+
+class Mapping
+
+  constructor: (@name, @missingText) ->
+    @dataPath = path.join DATAROOT, "#{@name}.json"
+    @data = null
+
+  isLoaded: -> @data?
+
+  loaded: (callback) ->
+    if @isLoaded then callback(null) else reloadThen(callback)
+
+  createThen: (callback) ->
+    @data = {}
+    fs.writeFile @dataPath, JSON.stringify(@data), encoding: 'utf-8', flag: 'wx', callback
+
+  reloadThen: (callback) ->
+    fs.readFile @dataPath, encoding: 'utf-8', (err, data) ->
+      if err?
+        callback(err)
+        return
+
+      @data = JSON.parse(data)
+      callback(null)
+
+  saveThen: (callback) ->
+    fs.writeFile @dataPath, JSON.stringify(@data), encoding: 'utf-8', callback
+
+  get: (username, callback) ->
+    @loaded (err) =>
+      if err?
+        callback(err)
+        return
+
+      callback(null, @data[username] or @missingText)
+
+  set: (username, value, callback) ->
+    @loaded (err) =>
+      if err?
+        callback(err)
+        return
+
+      @data[username] = value
+
+      @saveThen callback
+
+  @all: (callback) ->
+    fs.readdir DATAROOT, (err, files) ->
+      if err?
+        callback(err)
+        return
+
+      ms = []
+      for fileName in files
+        if fileName.indexOf('.json', file.length - 5) != -1
+          ms.push new Mapping(fileName.substring(0, fileName.length - 5))
+
+module.exports = (robot) ->
+
+  checkAuth = (msg) ->
+    unless robot.auth.hasRole(msg.message.user, ADMIN_ROLE)
+      msg.reply [
+        "You can't do that! You're not a *#{ADMIN_ROLE}*."
+        "Ask an admin to run `#{robot.name} grant #{msg.message.user.name} the #{ADMIN_ROLE}`."
+      ].join("\n")
+      return false
+    true
+
+  createMapping = (mapping) ->
+    robot.respond /#{mapping.name}(?:\s+@?(\S+))?/, (msg) ->
+      username = msg.match[1] or msg.message.user.name
+
+      mapping.get username, (err, value) ->
+        msg.reply "#{username}: #{value}"
+
+    robot.respond /set#{mapping.name}\s+@?(\S+)\s+(.+)/, (msg) ->
+      return unless checkAuth(msg)
+
+      username = msg.match[1]
+      value = msg.match[2]
+
+      mapping.set username, value, (err) ->
+
+  # Initial load.
+  Mapping.all (err, ms) ->
+    throw err if err?
+
+    createMapping(mapping) for mapping in ms
+
+  robot.respond /setupmapping\s+(\w+)\s+"([^"])"/, (msg) ->
+    return unless checkAuth(msg)
+
+    mapping = new Mapping(msg.match[1], msg.match[2])
+    mapping.createThen (err) ->
+      if err?
+        msg.reply "Couldn't create the mapping: #{err}"
+      else
+        createMapping(mapping)

--- a/scripts/mapping.coffee
+++ b/scripts/mapping.coffee
@@ -79,7 +79,7 @@ module.exports = (robot) ->
     unless robot.auth.hasRole(msg.message.user, ADMIN_ROLE)
       msg.reply [
         "You can't do that! You're not a *#{ADMIN_ROLE}*."
-        "Ask an admin to run `#{robot.name} grant #{msg.message.user.name} the #{ADMIN_ROLE}`."
+        "Ask an admin to run `#{robot.name} grant #{msg.message.user.name} the #{ADMIN_ROLE} role`."
       ].join("\n")
       return false
     true

--- a/scripts/mapping.coffee
+++ b/scripts/mapping.coffee
@@ -32,7 +32,7 @@ class Mapping
     fs.writeFile @dataPath, JSON.stringify(@data), encoding: 'utf-8', flag: 'wx', callback
 
   reloadThen: (callback) ->
-    fs.readFile @dataPath, encoding: 'utf-8', (err, data) ->
+    fs.readFile @dataPath, encoding: 'utf-8', (err, data) =>
       if err?
         callback(err)
         return

--- a/scripts/mapping.coffee
+++ b/scripts/mapping.coffee
@@ -106,7 +106,7 @@ module.exports = (robot) ->
 
     createMapping(mapping) for mapping in ms
 
-  robot.respond /setupmapping\s+(\w+)\s+"([^"])"/, (msg) ->
+  robot.respond /setupmapping\s+(\w+)\s+"([^"]+)"/i, (msg) ->
     return unless checkAuth(msg)
 
     mapping = new Mapping(msg.match[1], msg.match[2])

--- a/scripts/mapping.coffee
+++ b/scripts/mapping.coffee
@@ -115,3 +115,4 @@ module.exports = (robot) ->
         msg.reply "Couldn't create the mapping: #{err}"
       else
         createMapping(mapping)
+        msg.reply "Mapping created: #{mapping.name}"

--- a/scripts/mapping.coffee
+++ b/scripts/mapping.coffee
@@ -85,12 +85,15 @@ module.exports = (robot) ->
     true
 
   createMapping = (mapping) ->
+
+    robot.commands.push "#{mapping.name} <username> - Look up <username>'s currently assigned #{mapping.name}."
     robot.respond new RegExp("#{mapping.name}(?:\\s+@?(\\S+))?", 'i'), (msg) ->
       username = msg.match[1] or msg.message.user.name
 
       mapping.get username, (err, value) ->
         msg.send "#{username}: #{value}"
 
+    robot.commands.push "set#{mapping.name} <username> multi-word value - Set <username>'s #{mapping.name} to 'multi-word value'."
     robot.respond new RegExp("set#{mapping.name}\\s+@?(\\S+)\\s+(.+)", 'i'), (msg) ->
       return unless checkAuth(msg)
 


### PR DESCRIPTION
Create arbitrary mappings between users (or any text, really) and other text.

```
smash@winter ~/code/pushbot (mapping=) $ bin/hubot -n pushbot
pushbot> pushbot setupmapping motto "No motto for you"
pushbot> Shell: Mapping created: motto
pushbot> pushbot help motto
motto <username> - Look up <username>'s currently assigned motto.
setmotto <username> multi-word value - Set <username>'s motto to 'multi-word value'.
pushbot> pushbot setmotto @Shell I'm just not that into pokemon
pushbot> Shell's motto has been set to 'I'm just not that into pokemon'.
pushbot> pushbot motto
Shell: I'm just not that into pokemon
pushbot> pushbot motto Shell
Shell: I'm just not that into pokemon
pushbot>
smash@winter ~/code/pushbot (mapping=) $ cat botdata/motto.json 
{"Shell":"I'm just not that into pokemon"}
```