### PR TITLE
Hearthstone

### DIFF
--- a/scripts/hearthstone.coffee
+++ b/scripts/hearthstone.coffee
@@ -11,11 +11,11 @@
 
 module.exports = (robot) ->
 
-  robot.respond /hspopulate *(.+)/i, (msg) ->
-    url = msg.match[1]
+  robot.respond /hspopulate(?: (.*))?/i, (msg) ->
+    url = msg.match[1] or "http://hearthstonejson.com/json/AllSets.json"
     msg.http(url).get() (err, res, body) ->
       errmsg = "Couldn't download/parse/whatever that"
-      msg.send err
+      msg.send err if err
       try
         json = JSON.parse(body)
         robot.brain.data.hearthstone = {}

--- a/scripts/hearthstone.coffee
+++ b/scripts/hearthstone.coffee
@@ -2,8 +2,8 @@
 #   Look up information on hearthstone cards
 #
 # Commands:
-#   hspopulate <url> - (re)populate the brain with hearthstone data
-#   hearth <card> - look up card information
+#   hubot hspopulate <url> - (re)populate the brain with hearthstone data
+#   hubot hearth <card> - look up card information
 #
 # Configuration:
 #


### PR DESCRIPTION
 `pushbot hspopulate http://hearthstonejson.com/json/AllSets.json` fails silently.  I suspect the reason is that slack is auto-linking the http part and the bot's getting some kind of blob it doesn't know what to do with rather than a plain-text URL.  Leaving off the http doesn't solve the problem either, as apparently .com is enough to start the autolinker.

I'm not actually sure this solves the problem.  Doing a `pushbot hspopulate barf` should fail with `Error: connect ECONNREFUSED` but instead fails silently.  But it's the only idea I have.