### PR TITLE
Implement "decide" with better option parsing.

### DIFF
--- a/scripts/decide.coffee
+++ b/scripts/decide.coffee
@@ -50,4 +50,16 @@ module.exports = (robot) ->
 
   robot.respond /(?:decide|choose)(.*)/, (msg) ->
     options = parseOptions(msg.match[1])
-    msg.reply "options = [#{options.join '|'}]"
+    choice = msg.random options
+
+    msg.reply msg.random [
+      "Definitely #{choice}."
+      "Absolutely #{choice}."
+      "No question: #{choice}."
+      "#{choice}, no doubt about it."
+      "#{choice}, I guess."
+      "#{choice} all the way."
+      "Those are all terrible, but if you _have_ to pick one, go with #{choice}."
+      "All good options, but if you must... go with #{choice}."
+      "#{choice}! Now! Faster! THERE'S NO TIME!"
+    ]

--- a/scripts/decide.coffee
+++ b/scripts/decide.coffee
@@ -4,6 +4,8 @@
 # Commands:
 #   hubot decide "<option 1>" "<option 2>" "<option 3>" - Use complex algorithms and advanced AI to give sage advice
 
+_ = require 'underscore'
+
 parseOptions = (str) ->
   results = []
 
@@ -42,7 +44,7 @@ parseOptions = (str) ->
   # Complete the final option.
   results.push currentOption
 
-  results
+  _.without results, ""
 
 module.exports = (robot) ->
 

--- a/scripts/decide.coffee
+++ b/scripts/decide.coffee
@@ -1,0 +1,51 @@
+# Description:
+#   Help you make the hard decisions.
+#
+# Commands:
+#   hubot decide "<option 1>" "<option 2>" "<option 3>" - Use complex algorithms and advanced AI to give sage advice
+
+parseOptions = (str) ->
+  results = []
+
+  currentOption = ""
+  inQuotedOption = false
+  inPlainOption = false
+
+  for letter in str
+    switch
+      when inQuotedOption and letter is '"'
+        # End the current quoted option
+        results.push currentOption
+        currentOption = ""
+
+        inQuotedOption = false
+      when inQuotedOption
+        # Append to the current option, whitespace and all
+        currentOption += letter
+      when inPlainOption and /\s/.test letter
+        # End the current plain option
+        results.push currentOption
+        currentOption = ""
+
+        inPlainOption = false
+      when inPlainOption
+        # Append non-whitespace to the current option
+        currentOption += letter
+      when letter is '"'
+        # Begin a quoted option
+        inQuotedOption = true
+      when /\S/.test letter
+        # Begin a plain option with this character
+        inPlainOption = true
+        currentOption = letter
+
+  # Complete the final option.
+  results.push currentOption
+
+  results
+
+module.exports = (robot) ->
+
+  robot.respond /(?:decide|choose)(.*)/, (msg) ->
+    options = parseOptions(msg.match[1])
+    msg.reply "options = [#{options.join '|'}]"


### PR DESCRIPTION
It looks like we lost `decide` in the upgrade, so I'm re-implementing it. The option parsing it used was [kind of weird](https://github.com/github/hubot-scripts/blob/master/src/scripts/decide.coffee#L19-L20) too, so I'm trying to replace it with something a bit more predictable and shell-like.