### PR TITLE
[buffer]: Omit Messages with no room

### DIFF
--- a/scripts/buffer.coffee
+++ b/scripts/buffer.coffee
@@ -231,7 +231,7 @@ module.exports = (robot) ->
 
   # Accumulate Lines into the history buffer for each room.
   robot.catchAll (msg) ->
-    return unless msg.message.text
+    return unless msg.message.text and msg.message.room?
 
     Cache.forRoom(msg.message.room).append(msg)
 


### PR DESCRIPTION
This should address an exception I've been seeing in the logs:

```
[Sat Sep 24 2016 18:05:37 GMT-0400 (EDT)] ERROR TypeError: Cannot read property 'replace' of undefined
  at Function.Cache.forRoom (/var/pushbot/src/pushbot/scripts/buffer.coffee:24:24)
  at /var/pushbot/src/pushbot/scripts/buffer.coffee:236:11
  at Listener.callback (/var/pushbot/src/pushbot/node_modules/hubot/src/robot.coffee:236:52)
  at /var/pushbot/src/pushbot/node_modules/hubot/src/listener.coffee:65:12
  at allDone (/var/pushbot/src/pushbot/node_modules/hubot/src/middleware.coffee:44:37)
  at /var/pushbot/src/pushbot/node_modules/hubot/node_modules/async/lib/async.js:274:13
  at Object.async.eachSeries (/var/pushbot/src/pushbot/node_modules/hubot/node_modules/async/lib/async.js:142:20)
  at Object.async.reduce (/var/pushbot/src/pushbot/node_modules/hubot/node_modules/async/lib/async.js:268:15)
  at /var/pushbot/src/pushbot/node_modules/hubot/src/middleware.coffee:49:13
  at nextTickCallbackWith0Args (node.js:415:9)
  at process._tickCallback (node.js:344:13)
```