### PR TITLE
Create documents through the GraphQL API

### DIFF
--- a/bin/psql
+++ b/bin/psql
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -eu
+
+COMMAND="docker-compose exec postgres psql -U pushbot"
+
+case "${OSTYPE}" in
+  linux*) sudo -E ${COMMAND} ;;
+  *) ${COMMAND} ;;
+esac

--- a/scripts/api/cache.js
+++ b/scripts/api/cache.js
@@ -62,4 +62,4 @@ class CacheResolver {
   }
 }
 
-module.exports = CacheResolver
+module.exports = {CacheResolver}

--- a/scripts/api/cache.js
+++ b/scripts/api/cache.js
@@ -1,30 +1,10 @@
 const cache = require('../models/cache')
 const UserSetResolver = require('./user-set')
-
-const NullDataStore = {
-  getChannelGroupOrDMById () {
-    return null
-  },
-
-  getChannelByName () {
-    return null
-  }
-}
-
-function getDataStore (req) {
-  const adapter = req.robot.adapter
-  const client = adapter.client
-  if (!client) return NullDataStore
-  const rtm = client.rtm
-  if (!rtm) return NullDataStore
-  const dataStore = rtm.dataStore
-  if (!dataStore) return NullDataStore
-  return dataStore
-}
+const {getDataStore} = require('../helpers')
 
 class CacheResolver {
   knownChannels (options, req) {
-    const dataStore = getDataStore(req)
+    const dataStore = getDataStore(req.robot)
 
     return cache.known().map(id => {
       const channel = dataStore.getChannelGroupOrDMById(id)
@@ -33,7 +13,7 @@ class CacheResolver {
   }
 
   linesForChannel ({channel}, req) {
-    const dataStore = getDataStore(req)
+    const dataStore = getDataStore(req.robot)
 
     let existing = cache.forChannel(req.robot, channel, false)
     if (!existing) {

--- a/scripts/api/cache.js
+++ b/scripts/api/cache.js
@@ -1,5 +1,5 @@
 const cache = require('../models/cache')
-const UserSetResolver = require('./user-set')
+const {UserSetResolver} = require('./user-set')
 const {getDataStore} = require('../helpers')
 
 class CacheResolver {

--- a/scripts/api/document-set.js
+++ b/scripts/api/document-set.js
@@ -98,4 +98,4 @@ class DocumentSetResolver {
   }
 }
 
-module.exports = DocumentSetResolver
+module.exports = {DocumentSetResolver, DocumentResolver}

--- a/scripts/api/root.js
+++ b/scripts/api/root.js
@@ -1,6 +1,6 @@
-const UserSetResolver = require('./user-set')
-const DocumentSetResolver = require('./document-set')
-const CacheResolver = require('./cache')
+const {UserSetResolver} = require('./user-set')
+const {DocumentSetResolver, DocumentResolver} = require('./document-set')
+const {CacheResolver} = require('./cache')
 
 const bufferPreprocessor = require('../documentset/preprocessor/buffer')
 const cache = require('../models/cache')

--- a/scripts/api/root.js
+++ b/scripts/api/root.js
@@ -2,6 +2,9 @@ const UserSetResolver = require('./user-set')
 const DocumentSetResolver = require('./document-set')
 const CacheResolver = require('./cache')
 
+const bufferPreprocessor = require('../documentset/preprocessor/buffer')
+const cache = require('../models/cache')
+
 module.exports = {
   me (args, req) {
     return new UserSetResolver().me(args, req)
@@ -24,5 +27,41 @@ module.exports = {
 
   cache () {
     return new CacheResolver()
+  },
+
+  async createDocument ({set, channel, lines}, req) {
+    const sets = req.robot.documentSets || {}
+    const documentSet = sets[set]
+
+    if (!documentSet) throw new Error(`Unknown document set ${set}`)
+    const addSpec = documentSet.spec.features.add
+    if (!addSpec) throw new Error(`Cannot add to document set ${set}`)
+    if (addSpec.userOriented) throw new Error(`Document set ${set} requires a subject`)
+
+    const role = addSpec.role
+    if (!role.isAllowed(req.robot, req.user)) throw new Error(`You are not authorized to add to document set ${set}`)
+
+    const theCache = cache.forChannel(req.robot, channel, false)
+    if (!theCache) throw new Error(`No lines available in channel ${channel}`)
+
+    const ids = new Set(lines)
+    const chosen = theCache.lines.filter(line => ids.delete(line.id))
+    if (ids.size > 0) throw new Error(`Unable to find lines with IDs: ${Array.from(ids).join(', ')}`)
+    chosen.reverse()
+
+    const processed = bufferPreprocessor.fromLines(req.robot, chosen)
+    const formatted = addSpec.formatter(processed.lines, processed.speakers, processed.mentions)
+
+    const body = formatted.body
+    const attributes = []
+    for (const value of formatted.speakers) {
+      attributes.push({kind: 'speaker', value})
+    }
+    for (const value of formatted.mentions) {
+      attributes.push({kind: 'mention', value})
+    }
+
+    const doc = await documentSet.add(req.user.name, body, attributes)
+    return new DocumentSetResolver(doc)
   }
 }

--- a/scripts/api/schema.graphql
+++ b/scripts/api/schema.graphql
@@ -16,6 +16,12 @@ type Query {
   cache: Cache!
 }
 
+type Mutation {
+  # Create a new Document within a DocumentSet. Requires a user role specified by the named DocumentSet, like
+  # "quote pontiff" for the "quotes" set.
+  createDocument(set: String!, channel: String!, lines: [ID!]!): Document!
+}
+
 type UserSet {
   # Profile for the currently logged-in User.
   me: User!

--- a/scripts/api/user-set.js
+++ b/scripts/api/user-set.js
@@ -66,4 +66,4 @@ class UserSetResolver {
   }
 }
 
-module.exports = UserSetResolver
+module.exports = {UserSetResolver, UserResolver}

--- a/scripts/documentset/commands.js
+++ b/scripts/documentset/commands.js
@@ -5,6 +5,7 @@
 
 const util = require('util')
 const preprocessors = require('./preprocessor')
+const formatters = require('./formatter')
 
 exports.generate = function (robot, documentSet, spec) {
   if (spec.features.add !== null) {
@@ -55,19 +56,7 @@ function addCommands (robot, documentSet, spec, feature) {
   }
 
   if (!feature.formatter) {
-    feature.formatter = (lines, speakers, mentions, userTz) => ({
-      body: lines
-        .map(line => {
-          if (line.isRaw()) {
-            return line.text
-          } else {
-            return `[${line.timestamp.tz('America/New_York').format('h:mm A D MMM YYYY')}] ${line.speaker}: ${line.text}`
-          }
-        })
-        .join('\n'),
-      speakers,
-      mentions
-    })
+    feature.formatter = formatters.quote
   }
 
   const preprocessorNames = Object.keys(preprocessors)

--- a/scripts/documentset/formatter/index.js
+++ b/scripts/documentset/formatter/index.js
@@ -1,0 +1,7 @@
+// Export document formatters. Each formatter transforms its arguments (lines, speakers, mentions, userTz) into
+// an object with the spec {body, speakers, mentions}.
+
+module.exports = {
+  quote: require('./quote'),
+  lim: require('./lim')
+}

--- a/scripts/documentset/formatter/lim.js
+++ b/scripts/documentset/formatter/lim.js
@@ -1,0 +1,25 @@
+module.exports = function (lines, speakers, mentions) {
+  let body = lines.map(line => `> ${line.text}`).join('\n')
+
+  const atSpeakers = Array.from(speakers, speaker => '@' + speaker)
+
+  switch (atSpeakers.length) {
+    case 0:
+      body += '\n\n  - _anonymous_'
+      break
+    case 1:
+      body += `\n\n  - by @${atSpeakers[0]}`
+      break
+    case 2:
+      body += `\n\n  - a collaboration by ${atSpeakers.join(' and ')}`
+      break
+    default:
+      const allButLast = atSpeakers.slice(0, atSpeakers.length - 1)
+      const last = atSpeakers[atSpeakers.length - 1]
+
+      body += `\n\n - by ${allButLast.join(', ')} and ${last}`
+      break
+  }
+
+  return {body, speakers, mentions: []}
+}

--- a/scripts/documentset/formatter/quote.js
+++ b/scripts/documentset/formatter/quote.js
@@ -1,0 +1,15 @@
+module.exports = function (lines, speakers, mentions, userTz) {
+  return {
+    body: lines
+      .map(line => {
+        if (line.isRaw()) {
+          return line.text
+        } else {
+          return `[${line.timestamp.tz('America/New_York').format('h:mm A D MMM YYYY')}] ${line.speaker}: ${line.text}`
+        }
+      })
+      .join('\n'),
+    speakers,
+    mentions
+  }
+}

--- a/scripts/documentset/index.js
+++ b/scripts/documentset/index.js
@@ -58,7 +58,7 @@ exports.createDocumentSet = function createDocumentSet (robot, name, commands) {
   }
 
   const storage = new Storage({db: robot.postgres})
-  const documentSet = new DocumentSet(storage, spec.name, spec.nullBody)
+  const documentSet = new DocumentSet(storage, spec)
 
   generate(robot, documentSet, spec)
 

--- a/scripts/documentset/model.js
+++ b/scripts/documentset/model.js
@@ -4,11 +4,12 @@ const {BEFORE, AFTER, RANDOM, LATEST} = require('./storage')
 
 // A queryable collection of related documents.
 class DocumentSet {
-  constructor (storage, name, nullBody) {
+  constructor (storage, spec) {
     this.storage = storage
-    this.name = name
+    this.spec = spec
+    this.name = spec.name
 
-    this.nullDocument = new NullDocument(nullBody)
+    this.nullDocument = new NullDocument(spec.nullBody)
 
     this.connected = this.storage.connectDocumentSet(this)
   }

--- a/scripts/documentset/preprocessor/buffer.js
+++ b/scripts/documentset/preprocessor/buffer.js
@@ -26,11 +26,12 @@ function fromLines (robot, lines) {
   return {lines: result, speakers, mentions}
 }
 
-module.exports = function (robot, msg) {
+function preprocess (robot, msg) {
   const buffer = robot.bufferForUserId(msg.message.user.id)
   const lines = buffer.commit()
 
   return fromLines(lines)
 }
 
-exports.fromLines = fromLines
+preprocess.fromLines = fromLines
+module.exports = preprocess

--- a/scripts/documentset/preprocessor/buffer.js
+++ b/scripts/documentset/preprocessor/buffer.js
@@ -30,7 +30,7 @@ function preprocess (robot, msg) {
   const buffer = robot.bufferForUserId(msg.message.user.id)
   const lines = buffer.commit()
 
-  return fromLines(lines)
+  return fromLines(robot, lines)
 }
 
 preprocess.fromLines = fromLines

--- a/scripts/documentset/preprocessor/buffer.js
+++ b/scripts/documentset/preprocessor/buffer.js
@@ -2,10 +2,8 @@
 
 const createMentionDetector = require('./mentions')
 
-module.exports = function (robot, msg) {
-  const buffer = robot.bufferForUserId(msg.message.user.id)
+function fromLines (robot, lines) {
   const detector = createMentionDetector(robot)
-  const lines = buffer.commit()
 
   const result = []
   const speakers = new Set()
@@ -27,3 +25,12 @@ module.exports = function (robot, msg) {
 
   return {lines: result, speakers, mentions}
 }
+
+module.exports = function (robot, msg) {
+  const buffer = robot.bufferForUserId(msg.message.user.id)
+  const lines = buffer.commit()
+
+  return fromLines(lines)
+}
+
+exports.fromLines = fromLines

--- a/scripts/helpers/index.js
+++ b/scripts/helpers/index.js
@@ -6,6 +6,28 @@ function atRandom (list) {
   return list[index]
 }
 
+const NullDataStore = {
+  getChannelGroupOrDMById () {
+    return null
+  },
+
+  getChannelByName () {
+    return null
+  }
+}
+
+function getDataStore (robot) {
+  const adapter = robot.adapter
+  const client = adapter.client
+  if (!client) return NullDataStore
+  const rtm = client.rtm
+  if (!rtm) return NullDataStore
+  const dataStore = rtm.dataStore
+  if (!dataStore) return NullDataStore
+  return dataStore
+}
+
 module.exports = {
-  atRandom
+  atRandom,
+  getDataStore
 }

--- a/scripts/models/cache.js
+++ b/scripts/models/cache.js
@@ -20,8 +20,8 @@ class Cache {
     }
   }
 
-  append (msg) {
-    const now = moment.tz('America/New_York')
+  append (msg, ts = undefined) {
+    const now = ts || moment.tz('America/New_York')
     const toAdd = msg.message.text.split(/\n/).map(sourceLine => {
       return new Line(now, msg.message.user.name, sourceLine)
     })

--- a/scripts/quote.js
+++ b/scripts/quote.js
@@ -3,32 +3,7 @@
 
 const {createDocumentSet} = require('./documentset')
 const {Admin, QuotePontiff, PoetLaureate} = require('./roles')
-
-const limFormatter = (lines, speakers, mentions) => {
-  let body = lines.map(line => `> ${line.text}`).join('\n')
-
-  const atSpeakers = Array.from(speakers, speaker => '@' + speaker)
-
-  switch (atSpeakers.length) {
-    case 0:
-      body += '\n\n  - _anonymous_'
-      break
-    case 1:
-      body += `\n\n  - by @${atSpeakers[0]}`
-      break
-    case 2:
-      body += `\n\n  - a collaboration by ${atSpeakers.join(' and ')}`
-      break
-    default:
-      const allButLast = atSpeakers.slice(0, atSpeakers.length - 1)
-      const last = atSpeakers[atSpeakers.length - 1]
-
-      body += `\n\n - by ${allButLast.join(', ')} and ${last}`
-      break
-  }
-
-  return {body, speakers, mentions: []}
-}
+const formatter = require('./documentset/formatter')
 
 module.exports = function (robot) {
   if (!robot.postgres) {
@@ -51,7 +26,7 @@ module.exports = function (robot) {
   createDocumentSet(robot, 'lim', {
     add: {
       role: PoetLaureate,
-      formatter: limFormatter
+      formatter: formatter.lim
     },
     query: true,
     count: true,

--- a/scripts/roles/index.js
+++ b/scripts/roles/index.js
@@ -10,7 +10,7 @@ class Role {
   }
 
   verify (robot, msg) {
-    if (!this.isAllowed(msg.message.user, this.name)) {
+    if (!this.isAllowed(robot, msg.message.user)) {
       msg.reply([
         `You can't do that! You're not a *${this.name}*.`,
         `Ask an admin to run \`${robot.name} grant ${msg.message.user.name} the ${this.name} role\`.`

--- a/scripts/roles/index.js
+++ b/scripts/roles/index.js
@@ -33,7 +33,7 @@ exports.Admin = {
   },
 
   verify (robot, msg) {
-    if (!this.isAllowed(msg.message.user)) {
+    if (!exports.Admin.isAllowed(msg.message.user)) {
       msg.reply('Only an admin can do that.')
       return false
     }

--- a/scripts/roles/index.js
+++ b/scripts/roles/index.js
@@ -5,8 +5,12 @@ class Role {
     this.name = name
   }
 
+  isAllowed (robot, user) {
+    return robot.auth.hasRole(user, this.name)
+  }
+
   verify (robot, msg) {
-    if (!robot.auth.hasRole(msg.message.user, this.name)) {
+    if (!this.isAllowed(msg.message.user, this.name)) {
       msg.reply([
         `You can't do that! You're not a *${this.name}*.`,
         `Ask an admin to run \`${robot.name} grant ${msg.message.user.name} the ${this.name} role\`.`
@@ -19,12 +23,17 @@ class Role {
 }
 
 exports.Anyone = {
+  isAllowed: () => true,
   verify: () => true
 }
 
 exports.Admin = {
-  verify: (robot, msg) => {
-    if (!robot.auth.isAdmin(msg.message.user)) {
+  isAllowed (robot, user) {
+    return robot.auth.isAdmin(user)
+  },
+
+  verify (robot, msg) {
+    if (!this.isAllowed(msg.message.user)) {
       msg.reply('Only an admin can do that.')
       return false
     }

--- a/scripts/roles/index.js
+++ b/scripts/roles/index.js
@@ -33,7 +33,7 @@ exports.Admin = {
   },
 
   verify (robot, msg) {
-    if (!exports.Admin.isAllowed(msg.message.user)) {
+    if (!robot.auth.isAdmin(msg.message.user)) {
       msg.reply('Only an admin can do that.')
       return false
     }

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -8,7 +8,8 @@
     "database": true,
     "delay": true,
     "usesDatabase": true,
-    "loadHelp": true
+    "loadHelp": true,
+    "message": true
   },
   "rules": {
     "no-unused-expressions": "off"

--- a/test/api/cache.test.js
+++ b/test/api/cache.test.js
@@ -1,7 +1,7 @@
 const Helper = require('hubot-test-helper')
 const helper = new Helper([])
 
-const CacheResolver = require('../../scripts/api/cache')
+const {CacheResolver} = require('../../scripts/api/cache')
 const cache = require('../../scripts/models/cache')
 
 describe('CacheResolver', function () {

--- a/test/api/cache.test.js
+++ b/test/api/cache.test.js
@@ -4,15 +4,6 @@ const helper = new Helper([])
 const CacheResolver = require('../../scripts/api/cache')
 const cache = require('../../scripts/models/cache')
 
-function message (username, line) {
-  return {
-    message: {
-      text: line,
-      user: {name: username}
-    }
-  }
-}
-
 describe('CacheResolver', function () {
   let room, user, req, resolver
 

--- a/test/api/document-set.test.js
+++ b/test/api/document-set.test.js
@@ -1,5 +1,5 @@
 const {createDocumentSet} = require('../../scripts/documentset')
-const DocumentSetResolver = require('../../scripts/api/document-set')
+const {DocumentSetResolver} = require('../../scripts/api/document-set')
 
 describe('DocumentSetResolver', function () {
   let set, resolver

--- a/test/api/mutations.test.js
+++ b/test/api/mutations.test.js
@@ -1,10 +1,13 @@
 const Helper = require('hubot-test-helper')
+const moment = require('moment-timezone')
 const {createDocumentSet} = require('../../scripts/documentset')
 const cache = require('../../scripts/models/cache')
 
 const resolver = require('../../scripts/api/root')
 
 const helper = new Helper([])
+
+const ts = moment.tz('2017-10-16 21:30:00-0400', 'America/New_York')
 
 describe('GraphQL mutations', function () {
   let room, blarfSet
@@ -36,10 +39,10 @@ describe('GraphQL mutations', function () {
     let lineIDs
 
     beforeEach(function () {
-      const c = cache.forChannel(room.robot, 'general')
-        .append(message('aaa', 'line one'))
-        .append(message('bbb', 'line two\nline three'))
-        .append(message('ccc', 'line four'))
+      const c = cache.forChannel(room.robot, 'C100')
+        .append(message('aaa', 'line one'), ts)
+        .append(message('bbb', 'line two\nline three'), ts)
+        .append(message('ccc', 'line four'), ts)
 
       lineIDs = c.lines.map(line => line.id)
       lineIDs.reverse()
@@ -47,8 +50,8 @@ describe('GraphQL mutations', function () {
       room.robot.adapter.client = {
         rtm: {
           dataStore: {
-            getChannelGroupOrDMById (id) {
-              if (id === 'C100') return {name: 'general'}
+            getChannelByName (name) {
+              if (name === 'general') return {id: 'C100'}
               return undefined
             }
           }
@@ -58,20 +61,83 @@ describe('GraphQL mutations', function () {
 
     it('rejects a request from a user without the required role', function () {
       return resolver.createDocument(
-        {set: 'blarf', channel: 'general', lines: [lineIDs[0]]},
+        {set: 'blarf', channel: 'C100', lines: [lineIDs[0]]},
         {robot: room.robot, user: unauthorized}
       ).then(() => new Error('Did not reject'), err => expect(err.message).to.match(/not authorized/))
     })
 
     it('rejects a request with an invalid line ID', function () {
       return resolver.createDocument(
-        {set: 'blarf', channel: 'general', lines: ['no']},
+        {set: 'blarf', channel: 'C100', lines: ['no']},
         {robot: room.robot, user: authorized}
       ).then(() => new Error('Did not reject'), err => expect(err.message).to.match(/no/))
     })
 
-    it('rejects a request with an invalid channel')
-    it('adds a document from the cache')
-    it('chooses a channel by ID or name')
+    it('rejects a request with an invalid channel', function () {
+      return resolver.createDocument(
+        {set: 'blarf', channel: 'nope', lines: [lineIDs[0]]},
+        {robot: room.robot, user: authorized}
+      ).then(() => new Error('Did not reject'), err => expect(err.message).to.match(/nope/))
+    })
+
+    it('rejects requests with an empty line array', function () {
+      return resolver.createDocument(
+        {set: 'blarf', channel: 'C100', lines: []},
+        {robot: room.robot, user: authorized}
+      ).then(() => new Error('Did not reject'), err => expect(err.message).to.match(/at least one line/))
+    })
+
+    it('adds a document from the cache', async function () {
+      const docResolver = await resolver.createDocument(
+        {set: 'blarf', channel: 'C100', lines: [lineIDs[1], lineIDs[2]]},
+        {robot: room.robot, user: authorized}
+      )
+
+      expect(docResolver.found).to.be.true
+      expect(docResolver.text).to.equal(
+        '[9:30 PM 16 Oct 2017] bbb: line two\n' +
+        '[9:30 PM 16 Oct 2017] bbb: line three'
+      )
+      expect(docResolver.speakers()).to.have.members(['bbb'])
+      expect(docResolver.mentions()).to.be.empty
+
+      const doc = await blarfSet.singleMatching({speaker: ['bbb']})
+      expect(doc.wasFound()).to.be.true
+      expect(doc.id).to.equal(docResolver.id)
+      expect(doc.getBody()).to.equal(docResolver.text)
+    })
+
+    it('preserves the channel order cache of the chosen lines', async function () {
+      const docResolver = await resolver.createDocument(
+        {set: 'blarf', channel: 'C100', lines: [lineIDs[2], lineIDs[3], lineIDs[1]]},
+        {robot: room.robot, user: authorized}
+      )
+
+      expect(docResolver.found).to.be.true
+      expect(docResolver.text).to.equal(
+        '[9:30 PM 16 Oct 2017] bbb: line two\n' +
+        '[9:30 PM 16 Oct 2017] bbb: line three\n' +
+        '[9:30 PM 16 Oct 2017] ccc: line four'
+      )
+      expect(docResolver.speakers()).to.have.members(['bbb', 'ccc'])
+      expect(docResolver.mentions()).to.be.empty
+
+      const doc = await blarfSet.singleMatching({speaker: ['bbb']})
+      expect(doc.wasFound()).to.be.true
+      expect(doc.id).to.equal(docResolver.id)
+      expect(doc.getBody()).to.equal(docResolver.text)
+    })
+
+    it('chooses a channel by ID or name', async function () {
+      const docResolver = await resolver.createDocument(
+        {set: 'blarf', channel: 'general', lines: [lineIDs[0]]},
+        {robot: room.robot, user: authorized}
+      )
+
+      expect(docResolver.found).to.be.true
+      expect(docResolver.text).to.equal(
+        '[9:30 PM 16 Oct 2017] aaa: line one'
+      )
+    })
   })
 })

--- a/test/api/mutations.test.js
+++ b/test/api/mutations.test.js
@@ -1,0 +1,77 @@
+const Helper = require('hubot-test-helper')
+const {createDocumentSet} = require('../../scripts/documentset')
+const cache = require('../../scripts/models/cache')
+
+const resolver = require('../../scripts/api/root')
+
+const helper = new Helper([])
+
+describe('GraphQL mutations', function () {
+  let room, blarfSet
+  let authorized, unauthorized
+
+  beforeEach(function () {
+    usesDatabase(this)
+    cache.clear()
+
+    room = helper.createRoom({httpd: false})
+    room.robot.postgres = global.database
+
+    authorized = room.robot.brain.userForId('1', {name: 'authy'})
+    unauthorized = room.robot.brain.userForId('2', {name: 'fenris'})
+
+    blarfSet = createDocumentSet(room.robot, 'blarf', {
+      add: {
+        role: { isAllowed (robot, user) { return user === authorized } }
+      }
+    })
+  })
+
+  afterEach(function () {
+    room.destroy()
+    return blarfSet.destroy()
+  })
+
+  describe('createDocument', function () {
+    let lineIDs
+
+    beforeEach(function () {
+      const c = cache.forChannel(room.robot, 'general')
+        .append(message('aaa', 'line one'))
+        .append(message('bbb', 'line two\nline three'))
+        .append(message('ccc', 'line four'))
+
+      lineIDs = c.lines.map(line => line.id)
+      lineIDs.reverse()
+
+      room.robot.adapter.client = {
+        rtm: {
+          dataStore: {
+            getChannelGroupOrDMById (id) {
+              if (id === 'C100') return {name: 'general'}
+              return undefined
+            }
+          }
+        }
+      }
+    })
+
+    it('rejects a request from a user without the required role', function () {
+      return resolver.createDocument(
+        {set: 'blarf', channel: 'general', lines: [lineIDs[0]]},
+        {robot: room.robot, user: unauthorized}
+      ).then(() => new Error('Did not reject'), err => expect(err.message).to.match(/not authorized/))
+    })
+
+    it('rejects a request with an invalid line ID', function () {
+      return resolver.createDocument(
+        {set: 'blarf', channel: 'general', lines: ['no']},
+        {robot: room.robot, user: authorized}
+      ).then(() => new Error('Did not reject'), err => expect(err.message).to.match(/no/))
+    })
+
+    it('rejects a request with an invalid channel')
+    it('adds a document from the cache')
+    it('chooses a channel by ID or name')
+  })
+})

--- a/test/api/user-set.test.js
+++ b/test/api/user-set.test.js
@@ -1,7 +1,7 @@
 const Helper = require('hubot-test-helper')
 const helper = new Helper([])
 
-const UserSetResolver = require('../../scripts/api/user-set')
+const {UserSetResolver} = require('../../scripts/api/user-set')
 
 describe('UserSetResolver', function () {
   let room, self, req, resolver

--- a/test/globals.js
+++ b/test/globals.js
@@ -29,6 +29,15 @@ global.loadHelp = function (robot) {
   return new Promise(resolve => setTimeout(resolve, 200))
 }
 
+global.message = function (username, line) {
+  return {
+    message: {
+      text: line,
+      user: {name: username}
+    }
+  }
+}
+
 // eslint-disable-next-line no-extend-native
 Promise.prototype.tap = function (chunk) {
   return this.then((...values) => {


### PR DESCRIPTION
Introduce a mutation to the GraphQL API that allows you to create "documents" from cache lines with a request.