### PR TITLE
Expose user roles in GraphQL API

### DIFF
--- a/scripts/api/user-set.js
+++ b/scripts/api/user-set.js
@@ -41,8 +41,10 @@ class UserResolver {
     return new AvatarResolver(this.profile)
   }
 
-  roles () {
-    return []
+  roles (args, req) {
+    return req.robot.auth.userRoles(this.user).map(role => {
+      return {name: role}
+    })
   }
 }
 

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -9,6 +9,7 @@
     "delay": true,
     "usesDatabase": true,
     "loadHelp": true,
+    "loadAuth": true,
     "message": true
   },
   "rules": {

--- a/test/api/user-set.test.js
+++ b/test/api/user-set.test.js
@@ -6,13 +6,15 @@ const {UserSetResolver} = require('../../scripts/api/user-set')
 describe('UserSetResolver', function () {
   let room, self, req, resolver
 
-  beforeEach(function () {
+  beforeEach(async function () {
     room = helper.createRoom({httpd: false})
 
     const robot = room.robot
+    await loadAuth(robot, '1')
+
     const brain = robot.brain
 
-    self = brain.userForId('1', {name: 'self'})
+    self = brain.userForId('1', {name: 'self', roles: ['role one', 'role two']})
     brain.userForId('2', {name: 'two'})
     brain.userForId('3', {name: 'three'})
 
@@ -35,7 +37,7 @@ describe('UserSetResolver', function () {
     it('returns resolvers for all users', function () {
       const results = resolver.all({}, req)
       expect(results.map(each => each.user)).to.have.deep.members([
-        {id: '1', name: 'self'},
+        {id: '1', name: 'self', roles: ['role one', 'role two']},
         {id: '2', name: 'two'},
         {id: '3', name: 'three'}
       ])
@@ -137,6 +139,16 @@ describe('UserSetResolver', function () {
       expect(avatarResolver.image192).to.eql(undefined)
       expect(avatarResolver.image512).to.eql(undefined)
       expect(avatarResolver.image1024).to.eql(undefined)
+    })
+
+    it('accesses currently assigned roles', function () {
+      const userResolver = resolver.me({}, req)
+      const roles = userResolver.roles({}, req)
+      expect(roles).to.eql([
+        {name: 'admin'},
+        {name: 'role one'},
+        {name: 'role two'}
+      ])
     })
   })
 })

--- a/test/globals.js
+++ b/test/globals.js
@@ -2,6 +2,7 @@
 
 const pg = require('pg-promise')()
 const hubotHelp = require('hubot-help')
+const hubotAuth = require('hubot-auth')
 require('hubot-test-helper')
 
 global.expect = require('chai').expect
@@ -27,6 +28,13 @@ global.loadHelp = function (robot) {
   hubotHelp(robot, '*')
 
   return new Promise(resolve => setTimeout(resolve, 200))
+}
+
+global.loadAuth = function (robot, adminID = '0') {
+  process.env.HUBOT_AUTH_ADMIN = adminID
+  hubotAuth(robot, '*')
+
+  return new Promise(resolve => setTimeout(resolve, 20))
 }
 
 global.message = function (username, line) {


### PR DESCRIPTION
Programming tip of the day: if your API is returning an empty array, maybe it's because you hardcoded it to return an empty array.