### PR TITLE
Advanced mapping manipulation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,11 @@
         "negotiator": "0.6.1"
       }
     },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -44,6 +49,11 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
       "integrity": "sha1-fZcZb51br39pNeJZhVSe3SpsIzk="
+    },
+    "camelcase": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
     },
     "chai": {
       "version": "3.5.0",
@@ -309,6 +319,33 @@
         }
       }
     },
+    "cliui": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+      "requires": {
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wrap-ansi": "2.1.0"
+      },
+      "dependencies": {
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        }
+      }
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+    },
     "coffee-script": {
       "version": "1.12.6",
       "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.6.tgz",
@@ -401,6 +438,16 @@
         "vary": "1.1.1"
       }
     },
+    "cross-spawn": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "requires": {
+        "lru-cache": "4.1.1",
+        "shebang-command": "1.2.0",
+        "which": "1.3.0"
+      }
+    },
     "debug": {
       "version": "2.6.8",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
@@ -409,6 +456,11 @@
       "requires": {
         "ms": "2.0.0"
       }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "depd": {
       "version": "1.1.0",
@@ -1721,6 +1773,20 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
+    "execa": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+      "requires": {
+        "cross-spawn": "5.1.0",
+        "get-stream": "3.0.0",
+        "is-stream": "1.1.0",
+        "npm-run-path": "2.0.2",
+        "p-finally": "1.0.0",
+        "signal-exit": "3.0.2",
+        "strip-eof": "1.0.0"
+      }
+    },
     "express": {
       "version": "4.15.3",
       "resolved": "https://registry.npmjs.org/express/-/express-4.15.3.tgz",
@@ -2127,6 +2193,16 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
       "integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E=",
       "dev": true
+    },
+    "get-caller-file": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
+    },
+    "get-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
     },
     "graceful-fs": {
       "version": "4.1.11",
@@ -3666,6 +3742,11 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
+    "invert-kv": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -3680,6 +3761,24 @@
       "requires": {
         "builtin-modules": "1.1.1"
       }
+    },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "iterall": {
       "version": "1.1.1",
@@ -3955,6 +4054,14 @@
       "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.0.1.tgz",
       "integrity": "sha1-sC+kgW7vIajEs1yp5Skh/8iaMOk="
     },
+    "lcid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "requires": {
+        "invert-kv": "1.0.0"
+      }
+    },
     "load-json-file": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
@@ -3971,7 +4078,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-      "dev": true,
       "requires": {
         "p-locate": "2.0.0",
         "path-exists": "3.0.0"
@@ -3980,8 +4086,7 @@
         "path-exists": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-          "dev": true
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
         }
       }
     },
@@ -3996,6 +4101,23 @@
       "resolved": "https://registry.npmjs.org/log/-/log-1.4.0.tgz",
       "integrity": "sha1-S6HYkP3iSbAx3KA7w36q8yVlbxw="
     },
+    "lru-cache": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+      "requires": {
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
+      }
+    },
+    "mem": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+      "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+      "requires": {
+        "mimic-fn": "1.1.0"
+      }
+    },
     "mime-db": {
       "version": "1.27.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
@@ -4008,6 +4130,11 @@
       "requires": {
         "mime-db": "1.27.0"
       }
+    },
+    "mimic-fn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
+      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -4342,6 +4469,19 @@
         "validate-npm-package-license": "3.0.1"
       }
     },
+    "npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "requires": {
+        "path-key": "2.0.1"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+    },
     "oauth": {
       "version": "0.9.15",
       "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
@@ -4366,17 +4506,30 @@
         "wordwrap": "0.0.3"
       }
     },
+    "os-locale": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+      "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+      "requires": {
+        "execa": "0.7.0",
+        "lcid": "1.0.0",
+        "mem": "1.1.0"
+      }
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+    },
     "p-limit": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-      "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
-      "dev": true
+      "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw="
     },
     "p-locate": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-      "dev": true,
       "requires": {
         "p-limit": "1.1.0"
       }
@@ -4474,6 +4627,11 @@
       "requires": {
         "pinkie-promise": "2.0.1"
       }
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
     "path-parse": {
       "version": "1.0.5",
@@ -4657,6 +4815,11 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.4.4.tgz",
       "integrity": "sha512-GuuPazIvjW1DG26yLQgO+nagmRF/h9M4RaCtZWqu/eFW7csdZkQEwPJUeXX10d+LzmCnR9DuIZndqIOn3p2YoA=="
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "raw-body": {
       "version": "2.2.0",
@@ -5142,6 +5305,16 @@
         }
       }
     },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+    },
+    "require-main-filename": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+    },
     "resolve": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
@@ -5157,10 +5330,33 @@
       "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
       "dev": true
     },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+    },
     "setprototypeof": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
       "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "requires": {
+        "shebang-regex": "1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "spdx-correct": {
       "version": "1.0.2",
@@ -5188,11 +5384,53 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
       "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
     },
+    "string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "requires": {
+        "is-fullwidth-code-point": "2.0.0",
+        "strip-ansi": "4.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        }
+      }
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
     "strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
       "dev": true
+    },
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "tinycolor2": {
       "version": "1.4.1",
@@ -5246,10 +5484,91 @@
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.1.tgz",
       "integrity": "sha1-Z1Neu2lMHVIldFeYRmUyP1h+jTc="
     },
+    "which": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "requires": {
+        "isexe": "2.0.0"
+      }
+    },
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+    },
     "wordwrap": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
       "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+    },
+    "wrap-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "requires": {
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1"
+      },
+      "dependencies": {
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        }
+      }
+    },
+    "y18n": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+    },
+    "yargs": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.0.3.tgz",
+      "integrity": "sha512-DqBpQ8NAUX4GyPP/ijDGHsJya4tYqLQrjPr95HNsr1YwL3+daCfvBwg7+gIC6IdJhR2kATh3hb61vjzMWEtjdw==",
+      "requires": {
+        "cliui": "3.2.0",
+        "decamelize": "1.2.0",
+        "find-up": "2.1.0",
+        "get-caller-file": "1.0.2",
+        "os-locale": "2.1.0",
+        "require-directory": "2.1.1",
+        "require-main-filename": "1.0.1",
+        "set-blocking": "2.0.0",
+        "string-width": "2.1.1",
+        "which-module": "2.0.0",
+        "y18n": "3.2.1",
+        "yargs-parser": "8.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.0.0.tgz",
+      "integrity": "sha1-IdR2Mw5agieaS4gTRb8GYQLiGcY=",
+      "requires": {
+        "camelcase": "4.1.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "tinycolor2": "1.4.1",
     "twit": "2.2.5",
     "underscore": "1.8.3",
-    "uuid": "^3.1.0"
+    "uuid": "^3.1.0",
+    "yargs": "^10.0.3"
   },
   "engines": {
     "node": "0.10.x"

--- a/scripts/documentset/model.js
+++ b/scripts/documentset/model.js
@@ -14,6 +14,10 @@ class DocumentSet {
     this.connected = this.storage.connectDocumentSet(this)
   }
 
+  change (spec) {
+    if (spec.nullBody) this.nullDocument = new NullDocument(spec.nullBody)
+  }
+
   async add (submitter, body, attributes) {
     await this.connected
     const result = await this.storage.insertDocument(this, submitter, body, attributes)

--- a/scripts/helpers/index.js
+++ b/scripts/helpers/index.js
@@ -1,5 +1,7 @@
 // Grab-bag of utility functions.
 
+const yargs = require('yargs')
+
 function atRandom (list) {
   const max = list.length - 1
   const index = Math.floor(Math.random() * (max + 1))
@@ -27,7 +29,28 @@ function getDataStore (robot) {
   return dataStore
 }
 
+// Parse command options provided with shell-like syntax
+
+function parseArguments (msg, argline, fn) {
+  const y = fn(yargs)
+  return new Promise(resolve => {
+    y.parse(argline, (err, argv, output) => {
+      if (err) {
+        msg.reply(`:boom: You broke it!\n${msg}\n${this.yargs.help()}`)
+        resolve(null)
+      }
+
+      if (output) {
+        msg.reply(output)
+      }
+
+      resolve(argv)
+    })
+  })
+}
+
 module.exports = {
   atRandom,
-  getDataStore
+  getDataStore,
+  parseArguments
 }

--- a/scripts/mapping.js
+++ b/scripts/mapping.js
@@ -9,6 +9,14 @@ const {MapMaker, withName} = require('./roles')
 const mappings = new Map()
 
 module.exports = function (robot) {
+  function persistMappings () {
+    const payload = {}
+    for (const [name, {options}] of mappings) {
+      payload[name] = options
+    }
+    robot.brain.set('mappingMeta', payload)
+  }
+
   function loadMapping (name, options) {
     if (mappings.has(name)) {
       throw new Error(`There's already a mapping called ${name}, silly!`)
@@ -23,9 +31,6 @@ module.exports = function (robot) {
       query: {
         userOriented: true
       },
-      all: {
-        userOriented: true
-      },
       nullBody: options.null
     })
 
@@ -37,12 +42,7 @@ module.exports = function (robot) {
 
   function createMapping (name, options) {
     loadMapping(name, options)
-
-    const payload = {}
-    for (const [name, {options}] of mappings) {
-      payload[name] = options
-    }
-    robot.brain.set('mappingMeta', payload)
+    persistMappings()
   }
 
   robot.on('brainReady', () => {
@@ -123,13 +123,15 @@ module.exports = function (robot) {
     }
 
     if (args.roleOwn) {
+      options.roleOwn = args.roleOwn
       documentSet.spec.features.set.roleForSelf = withName(args.roleOwn)
     }
 
     if (args.roleOther) {
+      options.roleOther = args.roleOther
       documentSet.spec.features.set.roleForOther = withName(args.roleOther)
     }
-
+    persistMappings()
     msg.send(`Mapping ${name} changed. :party-corgi:`)
   })
 

--- a/scripts/roles/index.js
+++ b/scripts/roles/index.js
@@ -46,3 +46,9 @@ exports.QuotePontiff = new Role('quote pontiff')
 exports.PoetLaureate = new Role('poet laureate')
 
 exports.MapMaker = new Role('mapmaker')
+
+exports.withName = function (name, def = exports.Anyone) {
+  if (!name) return def
+  if (/^anyone$/i.test(name)) return exports.Anyone
+  return new Role(name)
+}

--- a/scripts/switchcodes.js
+++ b/scripts/switchcodes.js
@@ -1,0 +1,42 @@
+// Description:
+//   Special-case !allswitchcodes.
+//
+// Commands:
+//   hubot allswitchcodes - Dump everyone's Switch friend code.
+
+module.exports = function (robot) {
+  robot.respond(/allswitchcodes\b/i, async msg => {
+    const ds = robot.documentSets.switchcode
+    if (!ds) {
+      msg.reply('No switchcode mappings present.')
+      return
+    }
+
+    const {documents} = await ds.allMatching([], '')
+
+    let longestUsername = 0
+    for (const document of documents) {
+      const subject = document.getAttributes().find(attr => attr.kind === 'subject')
+      if (!subject) continue
+
+      longestUsername = Math.max(longestUsername, subject.value.length)
+    }
+
+    let response = ''
+
+    response += ':switch_left: Nintendo Switch Friend Codes :switch_right:\n```\n'
+    for (const document of documents) {
+      const subject = document.getAttributes().find(attr => attr.kind === 'subject')
+      if (!subject) continue
+
+      response += subject.value
+      for (let i = 0; i < longestUsername - subject.value.length; i++) response += ' '
+      response += ' | '
+      response += document.getBody()
+      response += '\n'
+    }
+    response += '\n```\n'
+
+    msg.send(response)
+  })
+}

--- a/test/api/user-set.test.js
+++ b/test/api/user-set.test.js
@@ -8,17 +8,15 @@ describe('UserSetResolver', function () {
 
   beforeEach(async function () {
     room = helper.createRoom({httpd: false})
+    await loadAuth(room, '1')
 
-    const robot = room.robot
-    await loadAuth(robot, '1')
-
-    const brain = robot.brain
+    const brain = room.robot.brain
 
     self = brain.userForId('1', {name: 'self', roles: ['role one', 'role two']})
     brain.userForId('2', {name: 'two'})
     brain.userForId('3', {name: 'three'})
 
-    req = {robot, user: self}
+    req = {robot: room.robot, user: self}
     resolver = new UserSetResolver()
   })
 

--- a/test/mappings.test.js
+++ b/test/mappings.test.js
@@ -88,7 +88,26 @@ describe('mappings', function () {
     await response('yep')
   })
 
-  it('configures the role required to set others with --role-other')
+  it('configures the role required to set others with --role-other', async function () {
+    usesDatabase(this)
+
+    await room.user.say('admin', '@hubot createmapping foo --role-other "fancy lad"')
+    await response('@admin mapping foo has been created. :sparkles:')
+    await delay(500)()
+
+    await room.user.say('dandy', '@hubot setfoo @fancy: nope')
+    await response("@dandy You can't do that! You're not a *fancy lad*.\n" +
+            'Ask an admin to run `hubot grant dandy the fancy lad role`.')
+
+    await room.user.say('fancy', '@hubot setfoo @dandy: yep')
+    await response("dandy's foo has been set to 'yep'.")
+
+    await room.user.say('dandy', '@hubot foo')
+    await response('yep')
+
+    await room.user.say('fancy', '@hubot foo')
+    await response("I don't know any foos that contain that!")
+  })
 
   it('configures the banner shown before !all with --all-banner')
 

--- a/test/mappings.test.js
+++ b/test/mappings.test.js
@@ -4,80 +4,104 @@ const helper = new Helper('../scripts/mapping.js')
 describe('mappings', function () {
   let room
 
-  beforeEach(function () {
+  beforeEach(async function () {
     room = helper.createRoom({httpd: false})
-
     room.robot.postgres = global.database
+    await loadAuth(room)
 
-    room.robot.auth = {
-      isAdmin: user => user.name === 'me',
-      hasRole: user => user.name === 'me'
-    }
+    const brain = room.robot.brain
+    brain.userForId('admin', {name: 'admin', roles: ['mapmaker']})
+    brain.userForId('fancy', {name: 'fancy', roles: ['fancy lad']})
+    brain.userForId('dandy', {name: 'dandy', roles: ['dandy lad']})
   })
 
-  afterEach(function () {
-    return room.user.say('me', '@hubot destroymapping foo')
-    .then(delay(200))
-    .then(() => room.destroy())
+  afterEach(async function () {
+    await room.user.say('admin', '@hubot destroymapping foo')
+    await delay(200)()
+    await room.destroy()
   })
 
   function responses () {
     return room.messages.filter(pair => pair[0] === 'hubot').map(pair => pair[1])
   }
 
-  function response (expected) {
-    return delay()().then(() => {
-      if (responses().indexOf(expected) === -1) {
-        console.log(room.messages)
-        expect.fail('', '', `"${expected}" response not seen.`)
-      }
-    })
+  async function response (expected) {
+    await delay()()
+    if (responses().indexOf(expected) === -1) {
+      console.log(room.messages)
+      throw new Error(`"${expected}" response not seen.`)
+    }
   }
 
-  it('creates a new mapping with !createmapping', function () {
+  it('creates a new mapping with !createmapping', async function () {
     usesDatabase(this)
 
-    return room.user.say('me', '@hubot createmapping foo')
-    .then(() => response('@me mapping foo has been created. :sparkles:'))
-    .then(delay(200))
-    .then(() => room.user.say('me', '@hubot setfoo @me: words words words'))
-    .then(() => response("me's foo has been set to 'words words words'."))
-    .then(() => room.user.say('me', '@hubot foo'))
-    .then(() => response('words words words'))
+    await room.user.say('admin', '@hubot createmapping foo')
+    await response('@admin mapping foo has been created. :sparkles:')
+    await delay(200)()
+    await room.user.say('admin', '@hubot setfoo @admin: words words words')
+    await response("admin's foo has been set to 'words words words'.")
+    await room.user.say('admin', '@hubot foo')
+    await response('words words words')
   })
 
-  it('specifies the null message with --null', function () {
+  it('specifies the null message with --null', async function () {
     usesDatabase(this)
 
-    return room.user.say('me', '@hubot createmapping foo --null="Nothing here."')
-    .then(() => response('@me mapping foo has been created. :sparkles:'))
-    .then(delay(500))
-    .then(() => room.user.say('me', '@hubot foo'))
-    .then(() => response('Nothing here.'))
+    await room.user.say('admin', '@hubot createmapping foo --null="Nothing here."')
+    await response('@admin mapping foo has been created. :sparkles:')
+    await delay(500)()
+    await room.user.say('admin', '@hubot foo')
+    await response('Nothing here.')
   })
 
-  it('fails if the mapping already exists', function () {
+  it('configures the role required to set your own with --role-own', async function () {
     usesDatabase(this)
 
-    return room.user.say('me', '@hubot createmapping foo')
-    .then(delay(200))
-    .then(() => room.user.say('me', '@hubot createmapping foo'))
-    .then(() => response("There's already a mapping called foo, silly!"))
+    await room.user.say('admin', '@hubot createmapping foo --role-own "fancy lad"')
+    await response('@admin mapping foo has been created. :sparkles:')
+    await delay(500)()
+
+    await room.user.say('dandy', '@hubot setfoo: nope')
+    await response("@dandy You can't do that! You're not a *fancy lad*.\n" +
+            'Ask an admin to run `hubot grant dandy the fancy lad role`.')
+
+    await room.user.say('fancy', '@hubot setfoo: yep')
+    await response("fancy's foo has been set to 'yep'.")
+
+    await room.user.say('dandy', '@hubot foo')
+    await response("I don't know any foos that contain that!")
+
+    await room.user.say('fancy', '@hubot foo')
+    await response('yep')
   })
 
-  it('destroys a mapping with !destroymapping', function () {
+  it('configures the role required to set others with --role-other')
+
+  it('configures the banner shown before !all with --all-banner')
+
+  it('fails if the mapping already exists', async function () {
     usesDatabase(this)
 
-    return room.user.say('me', '@hubot createmapping foo')
-    .then(delay(200))
-    .then(() => room.user.say('me', '@hubot destroymapping foo'))
-    .then(() => response('@me mapping foo has been destroyed. :fire:'))
+    await room.user.say('admin', '@hubot createmapping foo')
+    await delay(200)
+    await room.user.say('admin', '@hubot createmapping foo')
+    await response("There's already a mapping called foo, silly!")
   })
 
-  it('is okay to destroy a nonexistent mapping', function () {
+  it('destroys a mapping with !destroymapping', async function () {
     usesDatabase(this)
 
-    return room.user.say('me', '@hubot destroymapping blerp')
-    .then(() => response('@me mapping blerp does not exist.'))
+    await room.user.say('admin', '@hubot createmapping foo')
+    await delay(200)()
+    await room.user.say('admin', '@hubot destroymapping foo')
+    await response('@admin mapping foo has been destroyed. :fire:')
+  })
+
+  it('is okay to destroy a nonexistent mapping', async function () {
+    usesDatabase(this)
+
+    await room.user.say('admin', '@hubot destroymapping blerp')
+    await response('@admin mapping blerp does not exist.')
   })
 })

--- a/test/mappings.test.js
+++ b/test/mappings.test.js
@@ -109,8 +109,6 @@ describe('mappings', function () {
     await response("I don't know any foos that contain that!")
   })
 
-  it('configures the banner shown before !all with --all-banner')
-
   it('fails if the mapping already exists', async function () {
     usesDatabase(this)
 

--- a/test/mappings.test.js
+++ b/test/mappings.test.js
@@ -120,6 +120,20 @@ describe('mappings', function () {
     await response("There's already a mapping called foo, silly!")
   })
 
+  it('changes an existing mapping with !changemapping', async function () {
+    await room.user.say('admin', '@hubot createmapping foo')
+    await response('@admin mapping foo has been created. :sparkles:')
+
+    await room.user.say('dandy', '@hubot foo')
+    await response("I don't know any foos that contain that!")
+
+    await room.user.say('admin', '@hubot changemapping foo --null stuff')
+    await response('Mapping foo changed. :party-corgi:')
+
+    await room.user.say('dandy', '@hubot foo')
+    await response('stuff')
+  })
+
   it('destroys a mapping with !destroymapping', async function () {
     usesDatabase(this)
 

--- a/test/mappings.test.js
+++ b/test/mappings.test.js
@@ -17,7 +17,7 @@ describe('mappings', function () {
 
   afterEach(async function () {
     await room.user.say('admin', '@hubot destroymapping foo')
-    await delay(200)()
+    await delay(400)()
     await room.destroy()
   })
 

--- a/test/mappings.test.js
+++ b/test/mappings.test.js
@@ -25,12 +25,24 @@ describe('mappings', function () {
     return room.messages.filter(pair => pair[0] === 'hubot').map(pair => pair[1])
   }
 
-  async function response (expected) {
-    await delay()()
-    if (responses().indexOf(expected) === -1) {
-      console.log(room.messages)
-      throw new Error(`"${expected}" response not seen.`)
-    }
+  function response (expected) {
+    return new Promise((resolve, reject) => {
+      let count = 0
+
+      const check = () => {
+        if (responses().indexOf(expected) !== -1) {
+          resolve()
+        } else if (count > 20) {
+          console.log(room.messages)
+          return reject(new Error(`"${expected}" response not seen.`))
+        } else {
+          count++
+          setTimeout(check, 50)
+        }
+      }
+
+      check()
+    })
   }
 
   it('creates a new mapping with !createmapping', async function () {

--- a/test/quotes/documentset.test.js
+++ b/test/quotes/documentset.test.js
@@ -448,7 +448,7 @@ describe('createDocumentSet', function () {
     it('generates default help text', function () {
       usesDatabase(this)
 
-      return loadHelp(room.robot)
+      return loadHelp(room)
       .then(() => createDocumentSet(room.robot, 'blarf', {add: true}))
       .then(() => room.user.say('me', '@hubot help blarf'))
       .then(delay())
@@ -464,7 +464,7 @@ describe('createDocumentSet', function () {
     it('accepts custom help text', function () {
       usesDatabase(this)
 
-      return loadHelp(room.robot)
+      return loadHelp(room)
       .then(() => createDocumentSet(room.robot, 'blarf', {
         add: {
           helpText: [
@@ -646,7 +646,7 @@ describe('createDocumentSet', function () {
     it('generates default help text', function () {
       usesDatabase(this)
 
-      return loadHelp(room.robot)
+      return loadHelp(room)
       .then(() => createDocumentSet(room.robot, 'blarf', {set: true}))
       .then(() => room.user.say('me', '@hubot help'))
       .then(delay())
@@ -661,7 +661,7 @@ describe('createDocumentSet', function () {
     it('accepts custom help text', function () {
       usesDatabase(this)
 
-      return loadHelp(room.robot)
+      return loadHelp(room)
       .then(() => createDocumentSet(room.robot, 'blarf', {
         set: {
           helpText: [
@@ -889,7 +889,7 @@ describe('createDocumentSet', function () {
     })
 
     it('generates default help text', function () {
-      return loadHelp(room.robot)
+      return loadHelp(room)
       .then(() => createDocumentSet(room.robot, 'blarf', {query: true}))
       .then(() => room.user.say('me', '@hubot help blarf'))
       .then(delay())
@@ -902,7 +902,7 @@ describe('createDocumentSet', function () {
     })
 
     it('accepts custom help text', function () {
-      return loadHelp(room.robot)
+      return loadHelp(room)
       .then(() => createDocumentSet(room.robot, 'blarf', {
         query: {
           helpText: [
@@ -1079,7 +1079,7 @@ describe('createDocumentSet', function () {
     })
 
     it('generates default help text', function () {
-      return loadHelp(room.robot)
+      return loadHelp(room)
       .then(() => createDocumentSet(room.robot, 'blarf', {count: true}))
       .then(() => room.user.say('me', '@hubot help blarfcount'))
       .then(delay())
@@ -1092,7 +1092,7 @@ describe('createDocumentSet', function () {
     })
 
     it('accepts custom help text', function () {
-      return loadHelp(room.robot)
+      return loadHelp(room)
       .then(() => createDocumentSet(room.robot, 'blarf', {
         count: {
           helpText: [
@@ -1179,7 +1179,7 @@ describe('createDocumentSet', function () {
     it('generates default help text', function () {
       usesDatabase(this)
 
-      return loadHelp(room.robot)
+      return loadHelp(room)
       .then(() => createDocumentSet(room.robot, 'blarf', {stats: true}))
       .then(() => room.user.say('me', '@hubot help blarfstats'))
       .then(delay())
@@ -1194,7 +1194,7 @@ describe('createDocumentSet', function () {
     it('accepts custom help text', function () {
       usesDatabase(this)
 
-      return loadHelp(room.robot)
+      return loadHelp(room)
       .then(() => createDocumentSet(room.robot, 'blarf', {
         stats: {
           helpText: [
@@ -1344,7 +1344,7 @@ describe('createDocumentSet', function () {
       })
 
       it('generates default help text', function () {
-        return loadHelp(room.robot)
+        return loadHelp(room)
         .then(() => createDocumentSet(room.robot, 'blarf', {[commandName]: true}))
         .then(() => room.user.say('me', `@hubot help blarf${commandName}`))
         .then(delay())
@@ -1355,7 +1355,7 @@ describe('createDocumentSet', function () {
       })
 
       it('accepts custom help text', function () {
-        return loadHelp(room.robot)
+        return loadHelp(room)
         .then(() => createDocumentSet(room.robot, 'blarf', {
           [commandName]: {
             helpText: [


### PR DESCRIPTION
* Use a real argument parser for command arguments, to be less brittle than the `--null="([^"]+)"` regexps.
* Accept `--role-own` and `--role-other` arguments to `!createmapping`.
* Implement `!changemapping` to alter existing mappings after creation.

Fixes #118.