### PR TITLE
quotekov and limkov

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     environment:
       POSTGRES_USER: pushbot
       POSTGRES_PASSWORD: shhh
+    ports:
+    - '5432'
   pushbot:
     build: .
     volumes:

--- a/scripts/documentset/formatter/index.js
+++ b/scripts/documentset/formatter/index.js
@@ -3,6 +3,7 @@
 
 module.exports = {
   quote: require('./quote'),
+  markov: require('./markov'),
   lim: require('./lim'),
   brief: require('./brief')
 }

--- a/scripts/documentset/formatter/markov.js
+++ b/scripts/documentset/formatter/markov.js
@@ -1,0 +1,15 @@
+module.exports = function (lines, speakers, mentions, userTz) {
+  return {
+    body: lines
+      .map(line => {
+        if (line.isRaw()) {
+          return line.text
+        } else {
+          return `${line.speaker}: ${line.text}`
+        }
+      })
+      .join('\n'),
+    speakers,
+    mentions
+  }
+}

--- a/scripts/documentset/index.js
+++ b/scripts/documentset/index.js
@@ -60,6 +60,10 @@ exports.createDocumentSet = function createDocumentSet (robot, name, commands) {
   const storage = new Storage({db: robot.postgres})
   const documentSet = new DocumentSet(storage, spec)
 
+  if (spec.features.kov) {
+    robot.markov.createModel(`${spec.name}kov`, {})
+  }
+
   generate(robot, documentSet, spec)
 
   if (!robot.documentSets) {

--- a/scripts/documentset/index.js
+++ b/scripts/documentset/index.js
@@ -61,7 +61,15 @@ exports.createDocumentSet = function createDocumentSet (robot, name, commands) {
   const documentSet = new DocumentSet(storage, spec)
 
   if (spec.features.kov) {
-    robot.markov.createModel(`${spec.name}kov`, {})
+    const createModel = () => {
+      if (!robot.markov) {
+        setTimeout(createModel, 1)
+        return
+      }
+
+      robot.markov.createModel(`${spec.name}kov`, {})
+    }
+    createModel()
   }
 
   generate(robot, documentSet, spec)

--- a/scripts/quote.js
+++ b/scripts/quote.js
@@ -18,6 +18,7 @@ module.exports = function (robot) {
     stats: true,
     by: true,
     about: true,
+    kov: true,
 
     nullBody: "That wasn't notable enough to quote. Try harder."
   })
@@ -31,6 +32,7 @@ module.exports = function (robot) {
     query: true,
     count: true,
     by: true,
+    kov: true,
 
     nullBody: 'No limericks found.'
   })

--- a/test/globals.js
+++ b/test/globals.js
@@ -5,6 +5,7 @@ const pg = require('pg-promise')()
 const Hubot = require('hubot')
 const hubotHelp = require('hubot-help')
 const hubotAuth = require('hubot-auth')
+const hubotMarkov = require('hubot-markov')
 
 const Helper = require('hubot-test-helper')
 const moment = require('moment-timezone')
@@ -44,6 +45,7 @@ global.BotContext = class {
 
     if (global.database) {
       this.room.robot.postgres = global.database
+      this.room.robot.getDatabase = () => global.database
     }
   }
 
@@ -83,6 +85,11 @@ global.BotContext = class {
     }
 
     return new Promise(resolve => setTimeout(resolve, 20))
+  }
+
+  async loadMarkov () {
+    hubotMarkov(this.room.robot, '*')
+    await new Promise(resolve => setTimeout(resolve, 20))
   }
 
   say (...args) {

--- a/test/quotes/kov.test.js
+++ b/test/quotes/kov.test.js
@@ -1,0 +1,90 @@
+const {createDocumentSet} = require('../../scripts/documentset')
+
+describe('DocumentSet markov models', function () {
+  let bot, time, documentSet
+
+  beforeEach(async function () {
+    bot = new BotContext()
+    time = new TimeContext()
+
+    process.env.HUBOT_MARKOV_DEFAULT_MODEL = 'false'
+    process.env.HUBOT_MARKOV_REVERSE_MODEL = 'false'
+    await bot.loadMarkov()
+  })
+
+  afterEach(async function () {
+    await new Promise(resolve => {
+      try {
+        bot.getRobot().markov.modelNamed('blarfkov', model => model.destroy(resolve))
+      } catch (e) { resolve() }
+    })
+
+    bot.destroy()
+    time.destroy()
+    if (documentSet) {
+      return documentSet.destroy()
+    }
+  })
+
+  it('creates a markov model', async function () {
+    expect(() => bot.getRobot().markov.modelNamed('blarfkov', () => {})).to.throw(/Unrecognized model/)
+
+    documentSet = createDocumentSet(bot.getRobot(), 'blarf', {kov: true})
+
+    bot.getRobot().markov.modelNamed('blarfkov', model => {
+      expect(model).to.be.defined
+    })
+  })
+
+  it('adds new documents to the model', async function () {
+    documentSet = createDocumentSet(bot.getRobot(), 'blarf', {add: true, kov: true})
+
+    const blarfToAdd = 'person-one [2:00 PM] \n' +
+      'foo bar baz\n'
+
+    await documentSet.whenConnected()
+    await bot.say('me', `@hubot slackapp blarf: ${blarfToAdd}`)
+    await bot.waitForResponse('1 blarf loaded.')
+
+    const output = await new Promise((resolve, reject) => {
+      bot.getRobot().markov.modelNamed('blarfkov', model => {
+        model.generate('', 10, (err, text) => {
+          if (err) return reject(err)
+          resolve(text)
+        })
+      })
+    })
+    expect(output).to.equal('person-one: foo bar baz')
+  })
+
+  it('generates text from the model', async function () {
+    documentSet = createDocumentSet(bot.getRobot(), 'blarf', {kov: true})
+
+    await documentSet.whenConnected()
+    await new Promise(resolve => {
+      bot.getRobot().markov.modelNamed('blarfkov', model => {
+        model.learn('aaa bbb ccc', err => {
+          expect(err).to.be.null
+          resolve()
+        })
+      })
+    })
+
+    await bot.say('me', '@hubot blarfkov')
+    await bot.waitForResponse('aaa bbb ccc')
+  })
+
+  it('re-indexes the model from all documents', async function () {
+    documentSet = createDocumentSet(bot.getRobot(), 'blarf', {})
+    await documentSet.add('me', 'aaa bbb ccc', [])
+    await documentSet.add('me', 'aaa ddd eee', [])
+
+    documentSet = createDocumentSet(bot.getRobot(), 'blarf', {kov: true})
+    await documentSet.whenConnected()
+    await bot.say('me', '@hubot reindex blarfkov')
+    await bot.waitForResponse('@me Regenerated markov model from 2 blarfs.')
+
+    await bot.say('me', '@hubot blarfkov')
+    await bot.waitForResponse(/^aaa (bbb ccc|ddd eee)$/)
+  })
+})

--- a/test/quotes/kov.test.js
+++ b/test/quotes/kov.test.js
@@ -64,7 +64,7 @@ describe('DocumentSet markov models', function () {
     await new Promise(resolve => {
       bot.getRobot().markov.modelNamed('blarfkov', model => {
         model.learn('aaa bbb ccc', err => {
-          expect(err).to.be.null
+          expect(err).to.be.falsy
           resolve()
         })
       })


### PR DESCRIPTION
Enable `!quotekov` and `!limkov` by allowing any DocumentSet to have a corresponding markov model. Include a `!refresh quotekov` command to regenerate the model from existing quotes, to backfill.