### PR TITLE
Auto npm install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ ENV NPM_CONFIG_LOGLEVEL warn
 
 RUN apk add --no-cache bash postgresql-client
 RUN npm install -g coffee-script
-RUN adduser -s /bin/false -D -H pushbot
 RUN mkdir -p /usr/src/app
+RUN adduser -s /bin/false -D pushbot
 
 WORKDIR /usr/src/app
 ADD package.json /usr/src/app/package.json

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Once Docker is installed and running, build and pull containers with:
 # One-time setup
 docker-compose build
 docker-compose pull
-npm install
 touch .hubot_history
 chmod 666 .hubot_history
 ```

--- a/bin/container/entrypoint.sh
+++ b/bin/container/entrypoint.sh
@@ -11,4 +11,6 @@ ADAPTER=
 ALIAS="--alias !"
 [ "${DISABLE_ALIAS:-}" = "true" ] && ALIAS=
 
+[ -d /usr/src/app/node_modules ] || npm install
+
 exec /usr/src/app/node_modules/.bin/hubot --name pushbot --disable-httpd ${ALIAS} ${ADAPTER}


### PR DESCRIPTION
Automatically run `npm install` if necessary when launching the container, just in case you don't have node on your host machine.

/cc @Tuxedocat0 