### PR TITLE
This isn't rocket science, it's brain surgery

### DIFF
--- a/bin/pushbot.cmd
+++ b/bin/pushbot.cmd
@@ -1,6 +1,0 @@
-@echo off
-
-IF "%DEV_USERNAME%" == "" (SET DEV_USERNAME=%USER%)
-set HUBOT_AUTH_ADMIN=1
-
-docker-compose run --service-ports pushbot

--- a/bin/pushbot.ps1
+++ b/bin/pushbot.ps1
@@ -1,0 +1,7 @@
+if (!$env:DEV_USERNAME) {
+  $env:DEV_USERNAME = $env:USERNAME
+}
+
+$env:HUBOT_AUTH_ADMIN = "1"
+
+docker-compose run --service-ports pushbot

--- a/bin/test.cmd
+++ b/bin/test.cmd
@@ -1,0 +1,3 @@
+@echo off
+
+docker-compose --project-name pushbot-tests run --entrypoint /usr/src/app/bin/ci/test --rm pushbot

--- a/scripts/api/brain.js
+++ b/scripts/api/brain.js
@@ -1,0 +1,18 @@
+const {Admin} = require('../roles')
+
+function adminOnly (req) {
+  if (!Admin.isAllowed(req.robot, req.user)) throw new Error('You must be an admin to perform brain surgery')
+}
+
+class BrainResolver {
+  keys ({limit, prefix}, req) {
+    adminOnly(req)
+
+    const kvs = req.robot.brain.data._private
+    const ks = Object.keys(kvs).filter(each => each.startsWith(prefix))
+    ks.sort()
+    return ks.slice(0, limit)
+  }
+}
+
+module.exports = {BrainResolver}

--- a/scripts/api/brain.js
+++ b/scripts/api/brain.js
@@ -1,7 +1,41 @@
+const util = require('util')
+
 const {Admin} = require('../roles')
 
 function adminOnly (req) {
   if (!Admin.isAllowed(req.robot, req.user)) throw new Error('You must be an admin to perform brain surgery')
+}
+
+class EntryResolver {
+  constructor (target) {
+    this.target = target
+  }
+
+  children ({limit, prefix}, req) {
+    adminOnly(req)
+
+    const ks = Object.keys(this.target).filter(each => each.startsWith(prefix))
+    ks.sort()
+    return ks.slice(0, limit)
+  }
+
+  inspect ({depth}, req) {
+    adminOnly(req)
+
+    return util.inspect(this.target, {
+      depth,
+      customInspect: false,
+      showProxy: true,
+      maxArrayLength: 10,
+      breakLength: 100
+    })
+  }
+
+  json ({pretty}, req) {
+    adminOnly(req)
+
+    return JSON.stringify(this.target, null, '  ')
+  }
 }
 
 class BrainResolver {
@@ -12,6 +46,25 @@ class BrainResolver {
     const ks = Object.keys(kvs).filter(each => each.startsWith(prefix))
     ks.sort()
     return ks.slice(0, limit)
+  }
+
+  key ({name, property}, req) {
+    adminOnly(req)
+
+    const root = req.robot.brain.get(name)
+    if (root === null) {
+      throw new Error(`Unknown brain key ${name}`)
+    }
+
+    let target = root
+    for (const step of property) {
+      target = target[step]
+      if (target === undefined) {
+        throw new Error(`Invalid property ${step}`)
+      }
+    }
+
+    return new EntryResolver(target)
   }
 }
 

--- a/scripts/api/root.js
+++ b/scripts/api/root.js
@@ -1,6 +1,7 @@
 const {UserSetResolver} = require('./user-set')
 const {DocumentSetResolver, DocumentResolver} = require('./document-set')
 const {CacheResolver} = require('./cache')
+const {BrainResolver} = require('./brain')
 
 const bufferPreprocessor = require('../documentset/preprocessor/buffer')
 const briefFormatter = require('../documentset/formatter').brief
@@ -30,6 +31,10 @@ module.exports = {
 
   cache () {
     return new CacheResolver()
+  },
+
+  brain () {
+    return new BrainResolver()
   },
 
   calendarURL (args, req) {

--- a/scripts/api/root.js
+++ b/scripts/api/root.js
@@ -1,7 +1,7 @@
 const {UserSetResolver} = require('./user-set')
 const {DocumentSetResolver, DocumentResolver} = require('./document-set')
 const {CacheResolver} = require('./cache')
-const {BrainResolver} = require('./brain')
+const {BrainResolver, BrainMutator} = require('./brain')
 
 const bufferPreprocessor = require('../documentset/preprocessor/buffer')
 const briefFormatter = require('../documentset/formatter').brief
@@ -88,5 +88,7 @@ module.exports = {
 
     const doc = await documentSet.add(req.user.name, body, attributes)
     return new DocumentResolver(doc)
-  }
+  },
+
+  setBrainKey: BrainMutator.set
 }

--- a/scripts/api/schema.graphql
+++ b/scripts/api/schema.graphql
@@ -15,6 +15,9 @@ type Query {
   # Access the Cache of recent Lines seen by the bot.
   cache: Cache!
 
+  # Go digging around in pushbot's gooey grey matter. Admin-only.
+  brain: Brain!
+
   # URL at which your personal iCal feed is found.
   calendarURL: String!
 }
@@ -209,6 +212,28 @@ type Cache {
 
   # Access the stored data collected from a named channel. Returns null if no such channel is known.
   linesForChannel(channel: String!): [Line!]
+}
+
+# Single JavaScript object stored within the Brain.
+type Entry {
+  # Enumerate child properties. Admin-only.
+  children(limit: Int = 100, prefix: String = ""): [String!]!
+
+  # Inspect the entry with `util.inspect`. Admin-only.
+  inspect(depth: Int = 2): String!
+
+  # Render the entry as JSON if possible. Admin-only.
+  json(pretty: Boolean = false): String!
+}
+
+# Internal bot storage.
+type Brain {
+  # Enumerate top-level storage keys. Admin-only.
+  keys(limit: Int = 100, prefix: String = ""): [String!]!
+
+  # Access a top-level storage value at a named key. Optionally, descend into the object tree
+  # by following named properties. Admin-only.
+  key(name: String!, property: [String!] = []): Entry!
 }
 
 # Constraints on the Documents to be included in a query, count, or random

--- a/scripts/api/schema.graphql
+++ b/scripts/api/schema.graphql
@@ -26,6 +26,10 @@ type Mutation {
   # Create a new Document within a DocumentSet. Requires a user role specified by the named DocumentSet, like
   # "quote pontiff" for the "quotes" set.
   createDocument(set: String!, channel: String!, lines: [ID!]!): Document!
+
+  # Modify a value within the robot's internal storage. Very dangerous. And yes, this accepts a JSON-encoded
+  # string as an argument: don't @ me.
+  setBrainKey(name: String!, property: [String!] = [], value: String!): Entry!
 }
 
 type UserSet {

--- a/test/api/brain.test.js
+++ b/test/api/brain.test.js
@@ -1,0 +1,114 @@
+const util = require('util')
+
+const {BrainResolver} = require('../../scripts/api/brain')
+
+describe('BrainResolver', function () {
+  let bot, brain, req, resolver
+  let authorized, unauthorized
+
+  beforeEach(async function () {
+    bot = new BotContext()
+    await bot.loadAuth('1')
+
+    authorized = bot.createUser('1', 'authorized')
+    unauthorized = bot.createUser('2', 'denied')
+
+    brain = bot.getRobot().brain
+
+    req = {robot: bot.getRobot(), user: authorized}
+    resolver = new BrainResolver()
+  })
+
+  afterEach(function () {
+    bot.destroy()
+  })
+
+  describe('keys', function () {
+    let allKeys
+
+    beforeEach(function () {
+      allKeys = []
+      for (let i = 0; i < 10; i++) {
+        const prefix = i % 2 === 0 ? 'even' : 'odd'
+        const key = `${prefix}-key:${i}`
+        allKeys.push(key)
+        brain.set(key, `value ${i}`)
+      }
+    })
+
+    it('only permits admin access', function () {
+      expect(() => {
+        resolver.keys({}, {robot: bot.getRobot(), user: unauthorized})
+      }).to.throw(/must be an admin/)
+    })
+
+    it('lists known keys', function () {
+      expect(resolver.keys({limit: Infinity, prefix: ''}, req)).to.have.members(allKeys)
+    })
+
+    it('limits to the first N results', function () {
+      expect(resolver.keys({limit: 5, prefix: ''}, req)).to.have.length(5)
+    })
+
+    it('limits by a prefix', function () {
+      expect(resolver.keys({limit: Infinity, prefix: 'even'}, req)).to.have.members([
+        'even-key:0', 'even-key:2', 'even-key:4', 'even-key:6', 'even-key:8'
+      ])
+    })
+  })
+
+  describe('key', function () {
+    let root
+
+    beforeEach(function () {
+      root = {
+        key0: {
+          key00: 'astring',
+          key01: 100,
+          key02: null
+        },
+        key1: 'other'
+      }
+      brain.set('the-key', root)
+    })
+
+    it('only permits admin access', function () {
+      expect(() => {
+        resolver.key({name: 'the-key', property: []}, {robot: bot.getRobot(), user: unauthorized})
+      }).to.throw(/must be an admin/)
+    })
+
+    it('throws an error if the key is unknown', function () {
+      expect(() => resolver.key({name: 'bad-key', property: []}, req)).to.throw(/Unknown key/)
+    })
+
+    it('accesses the root-level object of a key as JSON', function () {
+      const json = resolver.key({name: 'the-key', property: []}, req).json({pretty: false}, req)
+      expect(JSON.parse(json)).to.deep.equal(root)
+    })
+
+    it('inspects the root-level object of a key with a given depth', function () {
+      const insp = resolver.key({name: 'the-key', property: []}, req).inspect({depth: 2}, req)
+      expect(insp).to.equal(util.inspect(root))
+    })
+
+    it('enumerates child properties of an object', function () {
+      const props = resolver.key({name: 'the-key', property: []}, req).children({}, req)
+      expect(props).to.deep.equal(['key0', 'key1'])
+    })
+
+    it('accesses a deep property of an object as JSON', function () {
+      const child = resolver.key({name: 'the-key', property: ['key0']}, req).json({pretty: false}, req)
+      expect(JSON.parse(child)).to.equal({key00: 'astring', key01: 100, key02: null})
+    })
+
+    it('inspects a deep property of an object', function () {
+      const child = resolver.key({name: 'the-key', property: ['key0', 'key00']}, req).inspect({depth: 1}, req)
+      expect(child).to.equal('"astring"')
+    })
+
+    it('throws an error if a property in the chain is invalid', function () {
+      expect(() => resolver.key({name: 'the-key', property: ['key0', 'no', 'yes']}, req)).to.throw(/Invalid property/)
+    })
+  })
+})


### PR DESCRIPTION
Extend the GraphQL API to allow admins to explore and modify the contents of the brain. This'll be a lot more convenient than mucking around in PostgreSQL to fix things up when the model gets fouled up somehow.

- [x] Query
- [x] Mutation