### PR TITLE
Lowercase

### DIFF
--- a/scripts/api/cache.js
+++ b/scripts/api/cache.js
@@ -34,7 +34,7 @@ class CacheResolver {
     return lines.map(line => {
       return {
         id: line.id,
-        speaker: userSetResolver.withName({name: line.speaker}, req),
+        speaker: line.speaker ? userSetResolver.withName({name: line.speaker}, req) : null,
         timestamp: line.timestamp.valueOf(),
         text: line.text
       }

--- a/scripts/api/schema.graphql
+++ b/scripts/api/schema.graphql
@@ -222,7 +222,7 @@ type Line {
   id: ID
 
   # Username of the Slack User who spoke this line.
-  speaker: User!
+  speaker: User
 
   # Timestamp at which this Line was spoken, expressed as milliseconds since the epoch. Encoded as a String because
   # GraphQL Ints are limited to 32 bits.


### PR DESCRIPTION
Fix a stacktrace that's occurring when attempting to access recent chatlogs:

```
TypeError: Cannot read property 'toLowerCase' of undefined
 at Brain.userForName (/usr/src/app/node_modules/hubot/src/brain.js:153:28)
 at UserSetResolver.withName (/usr/src/app/scripts/api/user-set.js:101:34)
 at lines.map.line (/usr/src/app/scripts/api/cache.js:37:34)
 at Array.map (<anonymous>:null:null) 
 at CacheResolver.linesForChannel (/usr/src/app/scripts/api/cache.js:34:18)
 at defaultFieldResolver (/usr/src/app/node_modules/graphql/execution/execute.js:849:36)
```