### PR TITLE
rem API

### DIFF
--- a/bin/bot.ps1
+++ b/bin/bot.ps1
@@ -1,21 +1,22 @@
 param (
-  [string]$configuration = ""
+    [string]$configuration = ""
 )
 
 if (!$env:DEV_USERNAME) {
-  $env:DEV_USERNAME = $env:USERNAME
+    $env:DEV_USERNAME = $env:USERNAME
 }
 
 if (Test-Path -Path "secrets\botrc.ps1") {
-  $secrets = "secrets\botrc.ps1"
-} else {
-  $secrets = "secrets\botrc.example.ps1"
+    $secrets = "secrets\botrc.ps1"
+}
+else {
+    $secrets = "secrets\botrc.example.ps1"
 }
 
 if ($configuration -ne "") {
-  $secrets = "secrets\botrc.$configuration.ps1"
+    $secrets = "secrets\botrc.$configuration.ps1"
 }
 
 . $secrets
 
-docker-compose --service-ports pushbot
+docker-compose run --service-ports pushbot

--- a/scripts/api/brain.js
+++ b/scripts/api/brain.js
@@ -1,93 +1,94 @@
-const util = require('util')
+const util = require("util");
 
-const { Admin } = require('../roles')
+const {Admin} = require("../roles");
 
-function adminOnly (req) {
-  if (!Admin.isAllowed(req.robot, req.user)) throw new Error('You must be an admin to perform brain surgery')
+function adminOnly(req) {
+  if (!Admin.isAllowed(req.robot, req.user))
+    throw new Error("You must be an admin to perform brain surgery");
 }
 
-function targetFrom (req, name, property) {
-  const root = req.robot.brain.get(name)
+function targetFrom(req, name, property) {
+  const root = req.robot.brain.get(name);
   if (root === null) {
-    throw new Error(`Unknown brain key ${name}`)
+    throw new Error(`Unknown brain key ${name}`);
   }
 
-  let target = root
+  let target = root;
   for (const step of property) {
-    target = target[step]
+    target = target[step];
     if (target === undefined) {
-      throw new Error(`Invalid property ${step}`)
+      throw new Error(`Invalid property ${step}`);
     }
   }
-  return target
+  return target;
 }
 
 class EntryResolver {
-  constructor (target) {
-    this.target = target
+  constructor(target) {
+    this.target = target;
   }
 
-  children ({ limit, prefix }, req) {
-    adminOnly(req)
+  children({limit, prefix}, req) {
+    adminOnly(req);
 
-    const ks = Object.keys(this.target).filter(each => each.startsWith(prefix))
-    ks.sort()
-    return ks.slice(0, limit)
+    const ks = Object.keys(this.target).filter(each => each.startsWith(prefix));
+    ks.sort();
+    return ks.slice(0, limit);
   }
 
-  inspect ({ depth }, req) {
-    adminOnly(req)
+  inspect({depth}, req) {
+    adminOnly(req);
 
     return util.inspect(this.target, {
       depth,
       customInspect: false,
       showProxy: true,
       maxArrayLength: 10,
-      breakLength: 100
-    })
+      breakLength: 100,
+    });
   }
 
-  json ({ pretty }, req) {
-    adminOnly(req)
+  json({pretty}, req) {
+    adminOnly(req);
 
-    return JSON.stringify(this.target, null, '  ')
+    return JSON.stringify(this.target, null, "  ");
   }
 }
 
 class BrainResolver {
-  keys ({ limit, prefix }, req) {
-    adminOnly(req)
+  keys({limit, prefix}, req) {
+    adminOnly(req);
 
-    const kvs = req.robot.brain.data._private
-    const ks = Object.keys(kvs).filter(each => each.startsWith(prefix))
-    ks.sort()
-    return ks.slice(0, limit)
+    const kvs = req.robot.brain.data._private;
+    const ks = Object.keys(kvs).filter(each => each.startsWith(prefix));
+    ks.sort();
+    return ks.slice(0, limit);
   }
 
-  key ({ name, property }, req) {
-    adminOnly(req)
-    const target = targetFrom(req, name, property)
-    return new EntryResolver(target)
+  key({name, property}, req) {
+    adminOnly(req);
+    const target = targetFrom(req, name, property);
+    return new EntryResolver(target);
   }
 }
 
 const BrainMutator = {
-  set ({ name, property, value }, req) {
-    adminOnly(req)
+  set({name, property, value}, req) {
+    adminOnly(req);
 
-    const parsed = JSON.parse(value)
+    const parsed = JSON.parse(value);
     if (property.length > 0) {
-      const prefix = property.slice(0, -1)
-      const last = property[property.length - 1]
+      const prefix = property.slice(0, -1);
+      const last = property[property.length - 1];
 
-      const target = targetFrom(req, name, prefix)
-      target[last] = parsed
-      return new EntryResolver(target)
+      const target = targetFrom(req, name, prefix);
+      target[last] = parsed;
+      return new EntryResolver(target);
     } else {
-      req.robot.brain.set(name, parsed)
-      return new EntryResolver(parsed)
+      req.robot.brain.set(name, parsed);
+      return new EntryResolver(parsed);
     }
-  }
-}
+  },
+};
 
-module.exports = { BrainResolver, BrainMutator }
+module.exports = {BrainResolver, BrainMutator};

--- a/scripts/api/cache.js
+++ b/scripts/api/cache.js
@@ -1,45 +1,52 @@
-const cache = require('../models/cache')
-const { UserSetResolver } = require('./user-set')
-const { getDataStore } = require('../helpers')
+const cache = require("../models/cache");
+const {UserSetResolver} = require("./user-set");
+const {getDataStore} = require("../helpers");
 
 class CacheResolver {
-  knownChannels (options, req) {
-    const dataStore = getDataStore(req.robot)
+  knownChannels(options, req) {
+    const dataStore = getDataStore(req.robot);
 
-    return cache.known(req.robot).map(id => {
-      const channel = dataStore.getChannelGroupOrDMById(id)
-      return channel ? channel.name : id
-    }).filter(Boolean)
+    return cache
+      .known(req.robot)
+      .map(id => {
+        const channel = dataStore.getChannelGroupOrDMById(id);
+        return channel ? channel.name : id;
+      })
+      .filter(Boolean);
   }
 
-  linesForChannel ({ channel }, req) {
-    const dataStore = getDataStore(req.robot)
+  linesForChannel({channel}, req) {
+    const dataStore = getDataStore(req.robot);
 
-    let existing = cache.forChannel(req.robot, channel, false)
+    let existing = cache.forChannel(req.robot, channel, false);
     if (!existing) {
-      const ch = dataStore.getChannelByName(channel)
+      const ch = dataStore.getChannelByName(channel);
       if (ch) {
-        existing = cache.forChannel(req.robot, ch.id, false)
+        existing = cache.forChannel(req.robot, ch.id, false);
       }
     }
 
     if (!existing) {
-      return null
+      return null;
     }
 
-    const userSetResolver = new UserSetResolver()
-    const lines = existing.lines.slice()
-    lines.reverse()
+    const userSetResolver = new UserSetResolver();
+    const lines = existing.lines.slice();
+    lines.reverse();
 
-    return lines.map(line => {
-      return {
-        id: line.id,
-        speaker: line.speaker ? userSetResolver.withName({ name: line.speaker }, req) : null,
-        timestamp: line.timestamp.valueOf(),
-        text: line.text
-      }
-    }).filter(result => Boolean(result.speaker))
+    return lines
+      .map(line => {
+        return {
+          id: line.id,
+          speaker: line.speaker
+            ? userSetResolver.withName({name: line.speaker}, req)
+            : null,
+          timestamp: line.timestamp.valueOf(),
+          text: line.text,
+        };
+      })
+      .filter(result => Boolean(result.speaker));
   }
 }
 
-module.exports = { CacheResolver }
+module.exports = {CacheResolver};

--- a/scripts/api/document-set.js
+++ b/scripts/api/document-set.js
@@ -1,101 +1,111 @@
-function attributesFrom (criteria) {
-  const attributes = {}
+function attributesFrom(criteria) {
+  const attributes = {};
   if (criteria.subject) {
-    attributes.subject = [criteria.subject]
+    attributes.subject = [criteria.subject];
   }
   if (criteria.speakers) {
-    attributes.speaker = criteria.speakers
+    attributes.speaker = criteria.speakers;
   }
   if (criteria.mentions) {
-    attributes.mention = criteria.mentions
+    attributes.mention = criteria.mentions;
   }
-  return attributes
+  return attributes;
 }
 
-function attrValuesWithKind (document, kind) {
-  return document.getAttributes()
+function attrValuesWithKind(document, kind) {
+  return document
+    .getAttributes()
     .filter(attr => attr.kind === kind)
-    .map(attr => attr.value)
+    .map(attr => attr.value);
 }
 
 class DocumentResolver {
-  constructor (document) {
-    this.document = document
+  constructor(document) {
+    this.document = document;
 
-    this.id = this.document.id
-    this.found = this.document.wasFound()
-    this.text = this.document.getBody()
+    this.id = this.document.id;
+    this.found = this.document.wasFound();
+    this.text = this.document.getBody();
   }
 
-  subject () {
-    const subjects = attrValuesWithKind(this.document, 'subject')
-    return subjects.length > 0 ? subjects[0] : null
+  subject() {
+    const subjects = attrValuesWithKind(this.document, "subject");
+    return subjects.length > 0 ? subjects[0] : null;
   }
 
-  speakers () {
-    return attrValuesWithKind(this.document, 'speaker')
+  speakers() {
+    return attrValuesWithKind(this.document, "speaker");
   }
 
-  mentions () {
-    return attrValuesWithKind(this.document, 'mention')
+  mentions() {
+    return attrValuesWithKind(this.document, "mention");
   }
 }
 
 class DocumentSetResolver {
-  constructor (name, set) {
-    this.name = name
-    this.set = set
-    this.statsPromise = null
+  constructor(name, set) {
+    this.name = name;
+    this.set = set;
+    this.statsPromise = null;
   }
 
-  async random ({ criteria }) {
+  async random({criteria}) {
     return new DocumentResolver(
-      await this.set.randomMatching(attributesFrom(criteria), criteria.query || '')
-    )
+      await this.set.randomMatching(
+        attributesFrom(criteria),
+        criteria.query || ""
+      )
+    );
   }
 
-  async all ({ criteria, first, after }) {
-    const attributes = attributesFrom(criteria)
-    const query = criteria.query || ''
+  async all({criteria, first, after}) {
+    const attributes = attributesFrom(criteria);
+    const query = criteria.query || "";
 
-    const [{ hasPreviousPage, hasNextPage, documents }, count] = await Promise.all([
+    const [
+      {hasPreviousPage, hasNextPage, documents},
+      count,
+    ] = await Promise.all([
       this.set.allMatching(attributes, query, first, after),
-      this.set.countMatching(attributes, query)
-    ])
+      this.set.countMatching(attributes, query),
+    ]);
 
     const edges = documents.map(doc => {
       return {
         cursor: doc.id,
-        node: new DocumentResolver(doc)
-      }
-    })
+        node: new DocumentResolver(doc),
+      };
+    });
 
     return {
       edges,
-      pageInfo: { count, hasPreviousPage, hasNextPage }
-    }
+      pageInfo: {count, hasPreviousPage, hasNextPage},
+    };
   }
 
-  mine (args, req) {
-    return this.random({ criteria: { subject: req.user.name } })
+  mine(args, req) {
+    return this.random({criteria: {subject: req.user.name}});
   }
 
-  async rank ({ speaker }) {
+  async rank({speaker}) {
     if (!this.statsPromise) {
-      this.statsPromise = this.set.getUserStats(['speaker'])
+      this.statsPromise = this.set.getUserStats(["speaker"]);
     }
-    const stats = (await this.statsPromise).getStats()
-    const stat = stats.find(stat => stat.getUsername() === speaker)
+    const stats = (await this.statsPromise).getStats();
+    const stat = stats.find(stat => stat.getUsername() === speaker);
     if (stat === undefined) {
-      return 0
+      return 0;
     } else {
-      return stat.getRank()
+      return stat.getRank();
     }
   }
 
-  count ({ criteria }) {
-    return this.set.countMatching(attributesFrom(criteria), criteria.query || '')
+  count({criteria}) {
+    return this.set.countMatching(
+      attributesFrom(criteria),
+      criteria.query || ""
+    );
   }
 }
 
-module.exports = { DocumentSetResolver, DocumentResolver }
+module.exports = {DocumentSetResolver, DocumentResolver};

--- a/scripts/api/rem.js
+++ b/scripts/api/rem.js
@@ -1,0 +1,33 @@
+class RemResolver {
+  get({key}, {robot}) {
+    const value = robot.rem.get(key);
+    if (value) {
+      return {key, value};
+    } else {
+      return null;
+    }
+  }
+
+  search({query, first, after}, {robot}) {
+    const limit = first || 100;
+    const afterInd = after ? parseInt(after, 10) + 1 : 0;
+
+    const keys = robot.rem.search(query);
+
+    return {
+      pageInfo: {
+        total: keys.length,
+        hasPreviousPage: afterInd > 0,
+        hasNextPage: keys.length - afterInd > limit,
+      },
+      edges: keys.slice(afterInd, afterInd + limit).map((key, i) => {
+        return {
+          cursor: (i + afterInd).toString(),
+          node: {key, value: robot.rem.get(key)},
+        };
+      }),
+    };
+  }
+}
+
+module.exports = {RemResolver};

--- a/scripts/api/rem.js
+++ b/scripts/api/rem.js
@@ -8,11 +8,14 @@ class RemResolver {
     }
   }
 
-  search({query, first, after}, {robot}) {
+  search({query, first, after, orderField, orderDirection}, {robot}) {
     const limit = first || 100;
     const afterInd = after ? parseInt(after, 10) + 1 : 0;
+    const field = orderField || "KEY";
+    const direction = orderDirection || "ASCENDING";
 
     const keys = robot.rem.search(query);
+    keys.sort(getComparator(field, direction));
 
     return {
       pageInfo: {
@@ -27,6 +30,18 @@ class RemResolver {
         };
       }),
     };
+  }
+}
+
+function getComparator(field, direction) {
+  if (field === "RANDOM") {
+    return () => Math.random() * 2 + -1;
+  } else if (field === "KEY") {
+    const adjust = direction === "ASCENDING" ? 1 : -1;
+    return (a, b) =>
+      a.localeCompare(b, undefined, {sensitivity: "base"}) * adjust;
+  } else {
+    throw new Error(`Invalid order field: ${field}`);
   }
 }
 

--- a/scripts/api/rem.js
+++ b/scripts/api/rem.js
@@ -19,7 +19,7 @@ class RemResolver {
 
     return {
       pageInfo: {
-        total: keys.length,
+        count: keys.length,
         hasPreviousPage: afterInd > 0,
         hasNextPage: keys.length - afterInd > limit,
       },

--- a/scripts/api/root.js
+++ b/scripts/api/root.js
@@ -1,94 +1,112 @@
-const { UserSetResolver } = require('./user-set')
-const { DocumentSetResolver, DocumentResolver } = require('./document-set')
-const { CacheResolver } = require('./cache')
-const { BrainResolver, BrainMutator } = require('./brain')
+const {UserSetResolver} = require("./user-set");
+const {DocumentSetResolver, DocumentResolver} = require("./document-set");
+const {CacheResolver} = require("./cache");
+const {BrainResolver, BrainMutator} = require("./brain");
+const {RemResolver} = require("./rem");
 
-const bufferPreprocessor = require('../documentset/preprocessor/buffer')
-const briefFormatter = require('../documentset/formatter').brief
-const { getDataStore } = require('../helpers')
-const cache = require('../models/cache')
-const { CalendarMap } = require('../models/calendar')
+const bufferPreprocessor = require("../documentset/preprocessor/buffer");
+const briefFormatter = require("../documentset/formatter").brief;
+const {getDataStore} = require("../helpers");
+const cache = require("../models/cache");
+const {CalendarMap} = require("../models/calendar");
 
 module.exports = {
-  me (args, req) {
-    return new UserSetResolver().me(args, req)
+  me(args, req) {
+    return new UserSetResolver().me(args, req);
   },
 
-  users () {
-    return new UserSetResolver()
+  users() {
+    return new UserSetResolver();
   },
 
-  documentSets (args, req) {
-    return Object.keys(req.robot.documentSets || {})
+  documentSets(args, req) {
+    return Object.keys(req.robot.documentSets || {});
   },
 
-  documents ({ set }, req) {
-    const sets = req.robot.documentSets || {}
-    const documentSet = sets[set]
+  documents({set}, req) {
+    const sets = req.robot.documentSets || {};
+    const documentSet = sets[set];
 
-    return documentSet && new DocumentSetResolver(set, documentSet)
+    return documentSet && new DocumentSetResolver(set, documentSet);
   },
 
-  cache () {
-    return new CacheResolver()
+  cache() {
+    return new CacheResolver();
   },
 
-  brain () {
-    return new BrainResolver()
+  brain() {
+    return new BrainResolver();
   },
 
-  calendarURL (args, req) {
-    const calendarId = CalendarMap.inRobot(req.robot).getCalendar(req.user.id, req.user.tz || 'America/New_York')
-    return `${process.env.API_BASE_URL}/ical/${calendarId}`
+  calendarURL(args, req) {
+    const calendarId = CalendarMap.inRobot(req.robot).getCalendar(
+      req.user.id,
+      req.user.tz || "America/New_York"
+    );
+    return `${process.env.API_BASE_URL}/ical/${calendarId}`;
   },
 
-  async createDocument ({ set, channel, lines }, req) {
-    const sets = req.robot.documentSets || {}
-    const documentSet = sets[set]
+  rem() {
+    return new RemResolver();
+  },
 
-    if (!documentSet) throw new Error(`Unknown document set ${set}`)
-    const addSpec = documentSet.spec.features.add
-    if (!addSpec) throw new Error(`Cannot add to document set ${set}`)
-    if (addSpec.userOriented) throw new Error(`Document set ${set} requires a subject`)
+  async createDocument({set, channel, lines}, req) {
+    const sets = req.robot.documentSets || {};
+    const documentSet = sets[set];
 
-    const role = addSpec.role
-    if (!role.isAllowed(req.robot, req.user)) throw new Error(`You are not authorized to add to document set ${set}`)
+    if (!documentSet) throw new Error(`Unknown document set ${set}`);
+    const addSpec = documentSet.spec.features.add;
+    if (!addSpec) throw new Error(`Cannot add to document set ${set}`);
+    if (addSpec.userOriented)
+      throw new Error(`Document set ${set} requires a subject`);
 
-    let existing = cache.forChannel(req.robot, channel, false)
+    const role = addSpec.role;
+    if (!role.isAllowed(req.robot, req.user))
+      throw new Error(`You are not authorized to add to document set ${set}`);
+
+    let existing = cache.forChannel(req.robot, channel, false);
     if (!existing) {
-      const ch = getDataStore(req.robot).getChannelByName(channel)
+      const ch = getDataStore(req.robot).getChannelByName(channel);
       if (ch) {
-        existing = cache.forChannel(req.robot, ch.id, false)
+        existing = cache.forChannel(req.robot, ch.id, false);
       }
     }
-    if (!existing) throw new Error(`No lines available in channel ${channel}`)
+    if (!existing) throw new Error(`No lines available in channel ${channel}`);
 
-    const ids = new Set(lines)
-    if (ids.size === 0) throw new Error('You must provide at least one line')
-    const chosen = existing.lines.filter(line => ids.delete(line.id))
-    if (ids.size > 0) throw new Error(`Unable to find lines with IDs: ${Array.from(ids).join(', ')}`)
-    chosen.reverse()
+    const ids = new Set(lines);
+    if (ids.size === 0) throw new Error("You must provide at least one line");
+    const chosen = existing.lines.filter(line => ids.delete(line.id));
+    if (ids.size > 0)
+      throw new Error(
+        `Unable to find lines with IDs: ${Array.from(ids).join(", ")}`
+      );
+    chosen.reverse();
 
-    const processed = bufferPreprocessor.fromLines(req.robot, chosen)
-    const formatted = addSpec.formatter(processed.lines, processed.speakers, processed.mentions)
+    const processed = bufferPreprocessor.fromLines(req.robot, chosen);
+    const formatted = addSpec.formatter(
+      processed.lines,
+      processed.speakers,
+      processed.mentions
+    );
 
     const announcement =
       `_<@${req.user.id}> quoted_\n` +
-      briefFormatter(processed.lines, processed.speakers, processed.mentions).body
-    req.robot.messageRoom(channel, announcement)
+      briefFormatter(processed.lines, processed.speakers, processed.mentions)
+        .body;
+    req.robot.messageRoom(channel, announcement);
 
-    const body = formatted.body
-    const attributes = []
+    const body = formatted.body;
+    const attributes = [];
     for (const value of formatted.speakers) {
-      attributes.push({ kind: 'speaker', value })
+      attributes.push({kind: "speaker", value});
     }
     for (const value of formatted.mentions) {
-      attributes.push({ kind: 'mention', value })
+      attributes.push({kind: "mention", value});
     }
 
-    const doc = await documentSet.add(req.user.name, body, attributes)
-    return new DocumentResolver(doc)
+    const doc = await documentSet.add(req.user.name, body, attributes);
+    return new DocumentResolver(doc);
   },
 
-  setBrainKey: BrainMutator.set
-}
+  setBrainKey: BrainMutator.set,
+};

--- a/scripts/api/schema.graphql
+++ b/scripts/api/schema.graphql
@@ -18,6 +18,9 @@ type Query {
   # Go digging around in pushbot's gooey grey matter. Admin-only.
   brain: Brain!
 
+  # Free-for-all key-value store.
+  rem: Rem!
+
   # URL at which your personal iCal feed is found.
   calendarURL: String!
 }
@@ -30,6 +33,20 @@ type Mutation {
   # Modify a value within the robot's internal storage. Very dangerous. And yes, this accepts a JSON-encoded
   # string as an argument: don't @ me.
   setBrainKey(name: String!, property: [String!] = [], value: String!): Entry!
+}
+
+# Metadata about the current page of results and its relationship with the full
+# result set.
+type PageInfo {
+  # The total number of results that were matched by the Criteria constraints
+  # across all possible pages.
+  count: Int!
+
+  # True if there is a page of results before this one.
+  hasPreviousPage: Boolean!
+
+  # True if there is a page of results after this one.
+  hasNextPage: Boolean!
 }
 
 type UserSet {
@@ -201,20 +218,6 @@ type Document {
   mentions: [String!]!
 }
 
-# Metadata about the current page of results and its relationship with the full
-# result set.
-type PageInfo {
-  # The total number of results that were matched by the Criteria constraints
-  # across all possible pages.
-  count: Int!
-
-  # True if there is a page of results before this one.
-  hasPreviousPage: Boolean!
-
-  # True if there is a page of results after this one.
-  hasNextPage: Boolean!
-}
-
 # Line of spoken text within a Cache collected by the bot from one of the channels the bot belongs to. Messages
 # that contain newlines are split into multiple Lines.
 type Line {
@@ -261,6 +264,44 @@ type Brain {
   # Access a top-level storage value at a named key. Optionally, descend into the object tree
   # by following named properties. Admin-only.
   key(name: String!, property: [String!] = []): Entry!
+}
+
+# Free-for-all key-value store
+type Rem {
+  get(key: String!): Memory
+
+  search(query: String, first: Int, after: String): MemoryConnection
+}
+
+# Paginated collection of Memories within Rem. As specified by:
+# https://facebook.github.io/relay/graphql/connections.htm
+type MemoryConnection {
+  # Paging support information.
+  pageInfo: PageInfo!
+
+  # Containers for results on the current page.
+  edges: [MemoryEdge!]!
+}
+
+# Paginated Memory result within Rem. As specified by:
+# https://facebook.github.io/relay/graphql/connections.htm
+type MemoryEdge {
+  # Opaque identifier used for paging. Supply the "cursor" of the final result
+  # in one page as the "after" parameter to the next query to retrieve the
+  # next page of results.
+  cursor: String!
+
+  # Single matching Memory.
+  node: Memory!
+}
+
+# Key-value pair stored by any User.
+type Memory {
+  # The full, exact key used to identify this Memory.
+  key: String!
+
+  # This Memory's value.
+  value: String!
 }
 
 # Constraints on the Documents to be included in a query, count, or random

--- a/scripts/api/schema.graphql
+++ b/scripts/api/schema.graphql
@@ -290,8 +290,8 @@ type Rem {
     query: String
     first: Int
     after: String
-    orderField: RemOrderField! = KEY
-    orderDirection: SortOrder! = ASCENDING
+    orderField: RemOrderField = KEY
+    orderDirection: SortDirection = ASCENDING
   ): MemoryConnection
 }
 

--- a/scripts/api/schema.graphql
+++ b/scripts/api/schema.graphql
@@ -49,6 +49,15 @@ type PageInfo {
   hasNextPage: Boolean!
 }
 
+# Common search result sort order values.
+enum SortDirection {
+  # Oldest to newest, lowest to highest, ...
+  ASCENDING
+
+  # Newest to oldest, highest to lowest, ...
+  DESCENDING
+}
+
 type UserSet {
   # Profile for the currently logged-in User.
   me: User!
@@ -266,11 +275,24 @@ type Brain {
   key(name: String!, property: [String!] = []): Entry!
 }
 
+enum RemOrderField {
+  KEY
+  RANDOM
+}
+
 # Free-for-all key-value store
 type Rem {
+  # Choose a specific key by exact, case-sensitive match. Return `null` if it does not exist.
   get(key: String!): Memory
 
-  search(query: String, first: Int, after: String): MemoryConnection
+  # Paginated, ordered search over all stored Memories.
+  search(
+    query: String
+    first: Int
+    after: String
+    orderField: RemOrderField! = KEY
+    orderDirection: SortOrder! = ASCENDING
+  ): MemoryConnection
 }
 
 # Paginated collection of Memories within Rem. As specified by:

--- a/scripts/api/user-set.js
+++ b/scripts/api/user-set.js
@@ -1,106 +1,114 @@
-const { TallyMap } = require('../models/tally-map')
-const { emojiCacheFor } = require('../models/emoji')
+const {TallyMap} = require("../models/tally-map");
+const {emojiCacheFor} = require("../models/emoji");
 
 class AvatarResolver {
-  constructor (profile) {
-    this.profile = profile
+  constructor(profile) {
+    this.profile = profile;
 
-    this.image24 = profile.image_24
-    this.image32 = profile.image_32
-    this.image48 = profile.image_48
-    this.image72 = profile.image_72
-    this.image192 = profile.image_192
-    this.image512 = profile.image_512
-    this.image1024 = profile.image_1024
+    this.image24 = profile.image_24;
+    this.image32 = profile.image_32;
+    this.image48 = profile.image_48;
+    this.image72 = profile.image_72;
+    this.image192 = profile.image_192;
+    this.image512 = profile.image_512;
+    this.image1024 = profile.image_1024;
   }
 }
 
 class StatusResolver {
-  constructor (profile) {
-    this.message = profile.status_text
-    this.emoji = profile.status_emoji
+  constructor(profile) {
+    this.message = profile.status_text;
+    this.emoji = profile.status_emoji;
   }
 }
 
 class UserResolver {
-  constructor (user) {
-    this.user = user
-    this.slack = this.user.slack || {}
-    this.profile = this.slack.profile || {}
+  constructor(user) {
+    this.user = user;
+    this.slack = this.user.slack || {};
+    this.profile = this.slack.profile || {};
 
-    this.id = this.user.id
-    this.name = this.user.name
-    this.realName = this.user.real_name
+    this.id = this.user.id;
+    this.name = this.user.name;
+    this.realName = this.user.real_name;
 
-    this.timezone = this.slack.tz
-    this.presence = (this.slack.presence || 'UNKNOWN').toUpperCase()
+    this.timezone = this.slack.tz;
+    this.presence = (this.slack.presence || "UNKNOWN").toUpperCase();
   }
 
-  status () {
-    return new StatusResolver(this.profile)
+  status() {
+    return new StatusResolver(this.profile);
   }
 
-  avatar () {
-    return new AvatarResolver(this.profile)
+  avatar() {
+    return new AvatarResolver(this.profile);
   }
 
-  roles (args, req) {
+  roles(args, req) {
     return req.robot.auth.userRoles(this.user).map(role => {
-      return { name: role }
-    })
+      return {name: role};
+    });
   }
 
-  topReactionsGiven ({ limit }, req) {
-    const emojiCache = emojiCacheFor(req.robot)
+  topReactionsGiven({limit}, req) {
+    const emojiCache = emojiCacheFor(req.robot);
 
-    const reactions = []
+    const reactions = [];
     const emojiPromise = async (name, count) => {
-      const url = await emojiCache.get(name)
-      return { count, emoji: { name, url } }
-    }
+      const url = await emojiCache.get(name);
+      return {count, emoji: {name, url}};
+    };
 
-    TallyMap.reactionsGiven(req.robot).topForUser(this.id, limit, (err, reaction, count) => {
-      if (err) throw err
-      reactions.push(emojiPromise(reaction, count))
-    })
-    return Promise.all(reactions)
+    TallyMap.reactionsGiven(req.robot).topForUser(
+      this.id,
+      limit,
+      (err, reaction, count) => {
+        if (err) throw err;
+        reactions.push(emojiPromise(reaction, count));
+      }
+    );
+    return Promise.all(reactions);
   }
 
-  topReactionsReceived ({ limit }, req) {
-    const emojiCache = emojiCacheFor(req.robot)
+  topReactionsReceived({limit}, req) {
+    const emojiCache = emojiCacheFor(req.robot);
 
-    const reactions = []
+    const reactions = [];
     const emojiPromise = async (name, count) => {
-      const url = await emojiCache.get(name)
-      return { count, emoji: { name, url } }
-    }
+      const url = await emojiCache.get(name);
+      return {count, emoji: {name, url}};
+    };
 
-    TallyMap.reactionsReceived(req.robot).topForUser(this.id, limit, (err, reaction, count) => {
-      if (err) throw err
-      reactions.push(emojiPromise(reaction, count))
-    })
-    return Promise.all(reactions)
+    TallyMap.reactionsReceived(req.robot).topForUser(
+      this.id,
+      limit,
+      (err, reaction, count) => {
+        if (err) throw err;
+        reactions.push(emojiPromise(reaction, count));
+      }
+    );
+    return Promise.all(reactions);
   }
 }
 
 class UserSetResolver {
-  me (args, req) {
-    return new UserResolver(req.user)
+  me(args, req) {
+    return new UserResolver(req.user);
   }
 
-  all (args, req) {
-    const resolvers = []
-    const userMap = req.robot.brain.users()
+  all(args, req) {
+    const resolvers = [];
+    const userMap = req.robot.brain.users();
     for (const uid of Object.keys(userMap)) {
-      resolvers.push(new UserResolver(userMap[uid]))
+      resolvers.push(new UserResolver(userMap[uid]));
     }
-    return resolvers
+    return resolvers;
   }
 
-  withName ({ name }, req) {
-    const user = req.robot.brain.userForName(name)
-    return user && new UserResolver(user)
+  withName({name}, req) {
+    const user = req.robot.brain.userForName(name);
+    return user && new UserResolver(user);
   }
 }
 
-module.exports = { UserSetResolver, UserResolver }
+module.exports = {UserSetResolver, UserResolver};

--- a/scripts/documentset/formatter/brief.js
+++ b/scripts/documentset/formatter/brief.js
@@ -1,15 +1,15 @@
-module.exports = function (lines, speakers, mentions, userTz) {
+module.exports = function(lines, speakers, mentions, userTz) {
   return {
     body: lines
       .map(line => {
         if (line.isRaw()) {
-          return line.text
+          return line.text;
         } else {
-          return `> ${line.speaker}: ${line.text}`
+          return `> ${line.speaker}: ${line.text}`;
         }
       })
-      .join('\n'),
+      .join("\n"),
     speakers,
-    mentions
-  }
-}
+    mentions,
+  };
+};

--- a/scripts/documentset/formatter/index.js
+++ b/scripts/documentset/formatter/index.js
@@ -2,8 +2,8 @@
 // an object with the spec {body, speakers, mentions}.
 
 module.exports = {
-  quote: require('./quote'),
-  markov: require('./markov'),
-  lim: require('./lim'),
-  brief: require('./brief')
-}
+  quote: require("./quote"),
+  markov: require("./markov"),
+  lim: require("./lim"),
+  brief: require("./brief"),
+};

--- a/scripts/documentset/formatter/lim.js
+++ b/scripts/documentset/formatter/lim.js
@@ -1,25 +1,25 @@
-module.exports = function (lines, speakers, mentions) {
-  let body = lines.map(line => `> ${line.text}`).join('\n')
+module.exports = function(lines, speakers, mentions) {
+  let body = lines.map(line => `> ${line.text}`).join("\n");
 
-  const atSpeakers = Array.from(speakers, speaker => '@' + speaker)
+  const atSpeakers = Array.from(speakers, speaker => "@" + speaker);
 
   switch (atSpeakers.length) {
     case 0:
-      body += '\n\n  - _anonymous_'
-      break
+      body += "\n\n  - _anonymous_";
+      break;
     case 1:
-      body += `\n\n  - by @${atSpeakers[0]}`
-      break
+      body += `\n\n  - by @${atSpeakers[0]}`;
+      break;
     case 2:
-      body += `\n\n  - a collaboration by ${atSpeakers.join(' and ')}`
-      break
+      body += `\n\n  - a collaboration by ${atSpeakers.join(" and ")}`;
+      break;
     default:
-      const allButLast = atSpeakers.slice(0, atSpeakers.length - 1)
-      const last = atSpeakers[atSpeakers.length - 1]
+      const allButLast = atSpeakers.slice(0, atSpeakers.length - 1);
+      const last = atSpeakers[atSpeakers.length - 1];
 
-      body += `\n\n - by ${allButLast.join(', ')} and ${last}`
-      break
+      body += `\n\n - by ${allButLast.join(", ")} and ${last}`;
+      break;
   }
 
-  return { body, speakers, mentions: [] }
-}
+  return {body, speakers, mentions: []};
+};

--- a/scripts/documentset/formatter/markov.js
+++ b/scripts/documentset/formatter/markov.js
@@ -1,15 +1,15 @@
-module.exports = function (lines, speakers, mentions, userTz) {
+module.exports = function(lines, speakers, mentions, userTz) {
   return {
     body: lines
       .map(line => {
         if (line.isRaw()) {
-          return line.text
+          return line.text;
         } else {
-          return `${line.speaker}: ${line.text}`
+          return `${line.speaker}: ${line.text}`;
         }
       })
-      .join('\n'),
+      .join("\n"),
     speakers,
-    mentions
-  }
-}
+    mentions,
+  };
+};

--- a/scripts/documentset/formatter/quote.js
+++ b/scripts/documentset/formatter/quote.js
@@ -1,15 +1,17 @@
-module.exports = function (lines, speakers, mentions, userTz) {
+module.exports = function(lines, speakers, mentions, userTz) {
   return {
     body: lines
       .map(line => {
         if (line.isRaw()) {
-          return line.text
+          return line.text;
         } else {
-          return `[${line.timestamp.tz('America/New_York').format('h:mm A D MMM YYYY')}] ${line.speaker}: ${line.text}`
+          return `[${line.timestamp
+            .tz("America/New_York")
+            .format("h:mm A D MMM YYYY")}] ${line.speaker}: ${line.text}`;
         }
       })
-      .join('\n'),
+      .join("\n"),
     speakers,
-    mentions
-  }
-}
+    mentions,
+  };
+};

--- a/scripts/documentset/index.js
+++ b/scripts/documentset/index.js
@@ -1,44 +1,45 @@
-'use strict'
+"use strict";
 
 // Entry point for the database-backed "quotefile" management API.
 
-const { DocumentSet } = require('./model')
-const { Storage } = require('./storage')
-const { generate } = require('./commands')
-const { Anyone } = require('../roles')
+const {DocumentSet} = require("./model");
+const {Storage} = require("./storage");
+const {generate} = require("./commands");
+const {Anyone} = require("../roles");
 
-function populateCommand (name, command, alwaysUserOriented = false) {
+function populateCommand(name, command, alwaysUserOriented = false) {
   if (command === undefined || command === null || command === false) {
-    return null
+    return null;
   }
 
-  const populated = Object.assign({}, command === true ? {} : command)
+  const populated = Object.assign({}, command === true ? {} : command);
 
   if (populated.role === undefined) {
-    populated.role = Anyone
+    populated.role = Anyone;
   }
 
   if (alwaysUserOriented || command.userOriented) {
     if (populated.roleForSelf === undefined) {
-      populated.roleForSelf = populated.role
+      populated.roleForSelf = populated.role;
     }
 
     if (populated.roleForOther === undefined) {
-      populated.roleForOther = populated.role
+      populated.roleForOther = populated.role;
     }
 
     if (populated.defaultToSelf === undefined) {
-      populated.defaultToSelf = false
+      populated.defaultToSelf = false;
     }
   }
 
-  return populated
+  return populated;
 }
 
 // Initialize commands related to a set of documents based on a spec.
-exports.createDocumentSet = function createDocumentSet (robot, name, commands) {
-  const plural = commands.plural || `${name}s`
-  const nullBody = commands.nullBody || `I don't know any ${plural} that contain that!`
+exports.createDocumentSet = function createDocumentSet(robot, name, commands) {
+  const plural = commands.plural || `${name}s`;
+  const nullBody =
+    commands.nullBody || `I don't know any ${plural} that contain that!`;
 
   const spec = {
     name,
@@ -53,31 +54,31 @@ exports.createDocumentSet = function createDocumentSet (robot, name, commands) {
       stats: populateCommand(name, commands.stats),
       by: populateCommand(name, commands.by),
       about: populateCommand(name, commands.about),
-      kov: populateCommand(name, commands.kov)
-    }
-  }
+      kov: populateCommand(name, commands.kov),
+    },
+  };
 
-  const storage = new Storage({ db: robot.postgres })
-  const documentSet = new DocumentSet(storage, spec)
+  const storage = new Storage({db: robot.postgres});
+  const documentSet = new DocumentSet(storage, spec);
 
   if (spec.features.kov) {
     const createModel = () => {
       if (!robot.markov) {
-        setTimeout(createModel, 1)
-        return
+        setTimeout(createModel, 1);
+        return;
       }
 
-      robot.markov.createModel(`${spec.name}kov`, {})
-    }
-    createModel()
+      robot.markov.createModel(`${spec.name}kov`, {});
+    };
+    createModel();
   }
 
-  generate(robot, documentSet, spec)
+  generate(robot, documentSet, spec);
 
   if (!robot.documentSets) {
-    robot.documentSets = {}
+    robot.documentSets = {};
   }
-  robot.documentSets[name] = documentSet
+  robot.documentSets[name] = documentSet;
 
-  return documentSet
-}
+  return documentSet;
+};

--- a/scripts/documentset/model.js
+++ b/scripts/documentset/model.js
@@ -1,316 +1,350 @@
 // Model classes for quotefile entries
 
-const { BEFORE, AFTER, RANDOM, LATEST } = require('./storage')
+const {BEFORE, AFTER, RANDOM, LATEST} = require("./storage");
 
 // A queryable collection of related documents.
 class DocumentSet {
-  constructor (storage, spec) {
-    this.storage = storage
-    this.spec = spec
-    this.name = spec.name
+  constructor(storage, spec) {
+    this.storage = storage;
+    this.spec = spec;
+    this.name = spec.name;
 
-    this.nullDocument = new NullDocument(spec.nullBody)
+    this.nullDocument = new NullDocument(spec.nullBody);
 
-    this.connected = this.storage.connectDocumentSet(this)
+    this.connected = this.storage.connectDocumentSet(this);
   }
 
-  change (spec) {
-    if (spec.nullBody) this.nullDocument = new NullDocument(spec.nullBody)
+  change(spec) {
+    if (spec.nullBody) this.nullDocument = new NullDocument(spec.nullBody);
   }
 
-  async add (submitter, body, attributes) {
-    await this.connected
-    const result = await this.storage.insertDocument(this, submitter, body, attributes)
-    return new Document(this, result)
+  async add(submitter, body, attributes) {
+    await this.connected;
+    const result = await this.storage.insertDocument(
+      this,
+      submitter,
+      body,
+      attributes
+    );
+    return new Document(this, result);
   }
 
-  async singleMatching (attributes, query, order) {
-    await this.connected
+  async singleMatching(attributes, query, order) {
+    await this.connected;
 
-    const row = await this.storage.singleDocumentMatching(this, attributes, query, order)
+    const row = await this.storage.singleDocumentMatching(
+      this,
+      attributes,
+      query,
+      order
+    );
     if (!row) {
-      return this.nullDocument
+      return this.nullDocument;
     }
 
-    const doc = new Document(this, row)
-    await doc.loadAttributes()
-    return doc
+    const doc = new Document(this, row);
+    await doc.loadAttributes();
+    return doc;
   }
 
-  randomMatching (attributes, query) {
-    return this.singleMatching(attributes, query, RANDOM)
+  randomMatching(attributes, query) {
+    return this.singleMatching(attributes, query, RANDOM);
   }
 
-  latestMatching (attributes, query) {
-    return this.singleMatching(attributes, query, LATEST)
+  latestMatching(attributes, query) {
+    return this.singleMatching(attributes, query, LATEST);
   }
 
-  async allMatching (attributes, query, first = null, cursor = null) {
-    await this.connected
+  async allMatching(attributes, query, first = null, cursor = null) {
+    await this.connected;
 
     const [rows, hasPreviousPage] = await Promise.all([
       this.storage.allDocumentsMatching(this, attributes, query, first, cursor),
       cursor !== null
-        ? this.storage.hasDocumentsMatching(this, attributes, query, cursor, BEFORE)
-        : false
-    ])
+        ? this.storage.hasDocumentsMatching(
+            this,
+            attributes,
+            query,
+            cursor,
+            BEFORE
+          )
+        : false,
+    ]);
 
-    const documents = rows.map(row => new Document(this, row))
-    const lastId = documents.length > 0
-      ? documents[documents.length - 1].id
-      : cursor
-    const byId = new Map(documents.map(doc => [doc.id, doc]))
+    const documents = rows.map(row => new Document(this, row));
+    const lastId =
+      documents.length > 0 ? documents[documents.length - 1].id : cursor;
+    const byId = new Map(documents.map(doc => [doc.id, doc]));
 
     const [attrRows, hasNextPage] = await Promise.all([
       this.storage.loadDocumentAttributes(this, documents),
-      this.storage.hasDocumentsMatching(this, attributes, query, first, lastId, AFTER)
-    ])
+      this.storage.hasDocumentsMatching(
+        this,
+        attributes,
+        query,
+        first,
+        lastId,
+        AFTER
+      ),
+    ]);
 
     for (const row of attrRows) {
-      const doc = byId.get(row.document_id)
+      const doc = byId.get(row.document_id);
       if (!doc) {
-        continue
+        continue;
       }
 
       if (doc.attributes === null) {
-        doc.attributes = []
+        doc.attributes = [];
       }
 
-      doc.attributes.push(new Attribute(doc, row))
+      doc.attributes.push(new Attribute(doc, row));
     }
 
     return {
       hasPreviousPage,
       hasNextPage,
-      documents
-    }
+      documents,
+    };
   }
 
-  async countMatching (attributes, query) {
-    await this.connected
+  async countMatching(attributes, query) {
+    await this.connected;
 
-    const row = await this.storage.countDocumentsMatching(this, attributes, query)
-    return parseInt(row.count)
+    const row = await this.storage.countDocumentsMatching(
+      this,
+      attributes,
+      query
+    );
+    return parseInt(row.count);
   }
 
-  async getUserStats (attributeKinds) {
-    await this.connected
-    const rows = await this.storage.attributeStats(this, attributeKinds)
+  async getUserStats(attributeKinds) {
+    await this.connected;
+    const rows = await this.storage.attributeStats(this, attributeKinds);
 
-    const statsByUsername = new Map()
+    const statsByUsername = new Map();
     for (const row of rows) {
-      let stat = statsByUsername.get(row.value)
+      let stat = statsByUsername.get(row.value);
       if (stat === undefined) {
-        stat = new UserStatistic(row.value)
-        statsByUsername.set(row.value, stat)
+        stat = new UserStatistic(row.value);
+        statsByUsername.set(row.value, stat);
       }
 
-      const count = parseInt(row.count)
-      stat.record(row.kind, count)
+      const count = parseInt(row.count);
+      stat.record(row.kind, count);
     }
 
-    const builder = new UserStatisticTableBuilder()
+    const builder = new UserStatisticTableBuilder();
     for (const stat of statsByUsername.values()) {
-      builder.append(stat)
+      builder.append(stat);
     }
-    return builder.build()
+    return builder.build();
   }
 
-  async deleteMatching (attributes) {
-    await this.connected
-    return this.storage.deleteDocumentsMatching(this, attributes)
+  async deleteMatching(attributes) {
+    await this.connected;
+    return this.storage.deleteDocumentsMatching(this, attributes);
   }
 
-  async destroy () {
-    await this.connected
-    return this.storage.destroyDocumentSet(this)
+  async destroy() {
+    await this.connected;
+    return this.storage.destroyDocumentSet(this);
   }
 
-  async truncate () {
-    await this.connected
-    return this.storage.truncateDocumentSet(this)
+  async truncate() {
+    await this.connected;
+    return this.storage.truncateDocumentSet(this);
   }
 
-  whenConnected () {
-    return this.connected
+  whenConnected() {
+    return this.connected;
   }
 
-  documentTableName () {
-    return `${this.name}_documents`
+  documentTableName() {
+    return `${this.name}_documents`;
   }
 
-  attributeTableName () {
-    return `${this.name}_attributes`
+  attributeTableName() {
+    return `${this.name}_attributes`;
   }
 }
 
 // An individual document contained within a DocumentSet.
 class Document {
-  constructor (set, result) {
-    this.set = set
+  constructor(set, result) {
+    this.set = set;
 
-    this.id = result.id
-    this.created = result.created
-    this.updated = result.updated
-    this.submitter = result.submitter
-    this.body = result.body
+    this.id = result.id;
+    this.created = result.created;
+    this.updated = result.updated;
+    this.submitter = result.submitter;
+    this.body = result.body;
 
     if (result.attributes) {
-      this.attributes = result.attributes.map(row => new Attribute(this, row))
+      this.attributes = result.attributes.map(row => new Attribute(this, row));
     } else {
-      this.attributes = null
+      this.attributes = null;
     }
   }
 
-  getBody () {
-    return this.body
+  getBody() {
+    return this.body;
   }
 
-  getAttributes () {
-    return this.attributes || []
+  getAttributes() {
+    return this.attributes || [];
   }
 
-  wasFound () {
-    return true
+  wasFound() {
+    return true;
   }
 
-  async loadAttributes () {
+  async loadAttributes() {
     if (this.attributes !== null) {
-      return
+      return;
     }
 
-    const rows = await this.set.storage.loadDocumentAttributes(this.set, [this])
-    this.attributes = rows.map(row => new Attribute(this, row))
+    const rows = await this.set.storage.loadDocumentAttributes(this.set, [
+      this,
+    ]);
+    this.attributes = rows.map(row => new Attribute(this, row));
   }
 }
 
 // A Document to be returned from queries that return no results.
 class NullDocument {
-  constructor (body) {
-    this.body = body
-    this.attributes = []
+  constructor(body) {
+    this.body = body;
+    this.attributes = [];
   }
 
-  getBody () {
-    return this.body
+  getBody() {
+    return this.body;
   }
 
-  getAttributes () {
-    return []
+  getAttributes() {
+    return [];
   }
 
-  loadAttributes () {
-    return Promise.resolve()
+  loadAttributes() {
+    return Promise.resolve();
   }
 
-  wasFound () {
-    return false
+  wasFound() {
+    return false;
   }
 }
 
 // Queryable document metadata.
 class Attribute {
-  constructor (doc, result) {
-    this.doc = doc
+  constructor(doc, result) {
+    this.doc = doc;
 
-    this.id = result.id
-    this.kind = result.kind
-    this.value = result.value
+    this.id = result.id;
+    this.kind = result.kind;
+    this.value = result.value;
   }
 }
 
-const padded = (str, length) => str + ' '.repeat(Math.max(length - str.length, 0))
+const padded = (str, length) =>
+  str + " ".repeat(Math.max(length - str.length, 0));
 
 class UserStatistic {
-  constructor (username) {
-    this.username = username
-    this.spokenCount = 0
-    this.mentionCount = 0
-    this.rank = 0
+  constructor(username) {
+    this.username = username;
+    this.spokenCount = 0;
+    this.mentionCount = 0;
+    this.rank = 0;
   }
 
-  record (kind, count) {
-    if (kind === 'speaker') {
-      this.spokenCount = count
-    } else if (kind === 'mention') {
-      this.mentionCount = count
+  record(kind, count) {
+    if (kind === "speaker") {
+      this.spokenCount = count;
+    } else if (kind === "mention") {
+      this.mentionCount = count;
     }
   }
 
-  getUsername (width = 0) {
-    return padded(this.username, width)
+  getUsername(width = 0) {
+    return padded(this.username, width);
   }
 
-  getSpokenCount (width = 0) {
-    return padded(this.spokenCount.toString(), width)
+  getSpokenCount(width = 0) {
+    return padded(this.spokenCount.toString(), width);
   }
 
-  getMentionCount (width = 0) {
-    return padded(this.mentionCount.toString(), width)
+  getMentionCount(width = 0) {
+    return padded(this.mentionCount.toString(), width);
   }
 
-  getRank () {
-    return this.rank
+  getRank() {
+    return this.rank;
   }
 }
 
 class UserStatisticTableBuilder {
-  constructor () {
-    this.stats = []
+  constructor() {
+    this.stats = [];
 
-    this.longestUsername = 0
-    this.longestSpoken = 0
-    this.longestMention = 0
+    this.longestUsername = 0;
+    this.longestSpoken = 0;
+    this.longestMention = 0;
   }
 
-  append (stat) {
-    this.stats.push(stat)
+  append(stat) {
+    this.stats.push(stat);
 
     if (stat.username.length > this.longestUsername) {
-      this.longestUsername = stat.username.length
+      this.longestUsername = stat.username.length;
     }
 
     if (stat.spokenCount.toString().length > this.longestSpoken) {
-      this.longestSpoken = stat.spokenCount.toString().length
+      this.longestSpoken = stat.spokenCount.toString().length;
     }
 
     if (stat.mentionCount.toString().length > this.longestMention) {
-      this.longestMention = stat.mentionCount.toString().length
+      this.longestMention = stat.mentionCount.toString().length;
     }
   }
 
-  build () {
+  build() {
     this.stats.sort((a, b) => {
       if (a.spokenCount !== b.spokenCount) {
-        return b.spokenCount - a.spokenCount
+        return b.spokenCount - a.spokenCount;
       } else {
-        return b.mentionCount - a.mentionCount
+        return b.mentionCount - a.mentionCount;
       }
-    })
+    });
     for (let i = 0; i < this.stats.length; i++) {
-      this.stats[i].rank = i + 1
+      this.stats[i].rank = i + 1;
     }
 
-    return new UserStatisticTable(this.stats, this.longestUsername, this.longestSpoken, this.longestMention)
+    return new UserStatisticTable(
+      this.stats,
+      this.longestUsername,
+      this.longestSpoken,
+      this.longestMention
+    );
   }
 }
 
 class UserStatisticTable {
-  constructor (stats, longestUsername, longestSpoken, longestMention) {
-    this.stats = stats
+  constructor(stats, longestUsername, longestSpoken, longestMention) {
+    this.stats = stats;
 
-    this.longestUsername = longestUsername
-    this.longestSpoken = longestSpoken
-    this.longestMention = longestMention
+    this.longestUsername = longestUsername;
+    this.longestSpoken = longestSpoken;
+    this.longestMention = longestMention;
   }
 
-  getStats () {
-    return this.stats
+  getStats() {
+    return this.stats;
   }
 
-  pad (header, length) {
-    return padded(header, length)
+  pad(header, length) {
+    return padded(header, length);
   }
 }
 
-exports.DocumentSet = DocumentSet
+exports.DocumentSet = DocumentSet;

--- a/scripts/documentset/preprocessor/buffer.js
+++ b/scripts/documentset/preprocessor/buffer.js
@@ -1,37 +1,37 @@
 // Accept the current contents of the user's buffer.
 
-const createMentionDetector = require('./mentions')
+const createMentionDetector = require("./mentions");
 
-function fromLines (robot, lines) {
-  const detector = createMentionDetector(robot)
+function fromLines(robot, lines) {
+  const detector = createMentionDetector(robot);
 
-  const result = []
-  const speakers = new Set()
-  const mentions = new Set()
+  const result = [];
+  const speakers = new Set();
+  const mentions = new Set();
 
   for (let i = 0; i < lines.length; i++) {
-    const line = lines[i]
+    const line = lines[i];
 
     for (const mention of detector.scan(line.text)) {
-      mentions.add(mention)
+      mentions.add(mention);
     }
 
     if (!line.isRaw()) {
-      speakers.add(line.speaker)
+      speakers.add(line.speaker);
     }
 
-    result.push(line)
+    result.push(line);
   }
 
-  return { lines: result, speakers, mentions }
+  return {lines: result, speakers, mentions};
 }
 
-function preprocess (robot, msg) {
-  const buffer = robot.bufferForUserId(msg.message.user.id)
-  const lines = buffer.commit()
+function preprocess(robot, msg) {
+  const buffer = robot.bufferForUserId(msg.message.user.id);
+  const lines = buffer.commit();
 
-  return fromLines(robot, lines)
+  return fromLines(robot, lines);
 }
 
-preprocess.fromLines = fromLines
-module.exports = preprocess
+preprocess.fromLines = fromLines;
+module.exports = preprocess;

--- a/scripts/documentset/preprocessor/index.js
+++ b/scripts/documentset/preprocessor/index.js
@@ -1,30 +1,30 @@
 // Export quote parsers as a convenient map.
 
 // Standard preprocessing.
-function processThen (parser) {
-  return function (robot, msg) {
-    const preprocessed = msg.match[1].replace(/\u200B/g, '')
-    return parser(robot, preprocessed)
-  }
+function processThen(parser) {
+  return function(robot, msg) {
+    const preprocessed = msg.match[1].replace(/\u200B/g, "");
+    return parser(robot, preprocessed);
+  };
 }
 
 exports.verbatim = {
   argument: true,
   echo: false,
-  defaultHelpText: 'Insert a %s exactly as given.',
-  call: processThen(require('./verbatim'))
-}
+  defaultHelpText: "Insert a %s exactly as given.",
+  call: processThen(require("./verbatim")),
+};
 
 exports.slackapp = {
   argument: true,
   echo: false,
   defaultHelpText: "Parse a %s from the Slack app's paste format.",
-  call: processThen(require('./slackapp'))
-}
+  call: processThen(require("./slackapp")),
+};
 
 exports.buffer = {
   argument: false,
   echo: true,
-  defaultHelpText: 'Insert a %s from the current contents of your buffer.',
-  call: require('./buffer')
-}
+  defaultHelpText: "Insert a %s from the current contents of your buffer.",
+  call: require("./buffer"),
+};

--- a/scripts/documentset/preprocessor/mentions.js
+++ b/scripts/documentset/preprocessor/mentions.js
@@ -1,36 +1,36 @@
 const never = {
-  exec () {
-    return undefined
-  }
-}
+  exec() {
+    return undefined;
+  },
+};
 
 class Detector {
-  constructor (robot) {
-    const userMap = robot.brain.users()
-    const usernames = Object.keys(userMap).map(uid => userMap[uid].name)
+  constructor(robot) {
+    const userMap = robot.brain.users();
+    const usernames = Object.keys(userMap).map(uid => userMap[uid].name);
 
     if (usernames.length > 0) {
-      const rxBody = `\\b@?(${usernames.join('|')}):?\\b`
-      this.rx = new RegExp(rxBody, 'ig')
+      const rxBody = `\\b@?(${usernames.join("|")}):?\\b`;
+      this.rx = new RegExp(rxBody, "ig");
     } else {
-      this.rx = never
+      this.rx = never;
     }
   }
 
-  scan (text) {
-    const mentions = new Set()
-    this.rx.lastIndex = 0
+  scan(text) {
+    const mentions = new Set();
+    this.rx.lastIndex = 0;
 
-    let match = this.rx.exec(text)
+    let match = this.rx.exec(text);
     while (match) {
-      mentions.add(match[1])
+      mentions.add(match[1]);
 
-      match = this.rx.exec(text)
+      match = this.rx.exec(text);
     }
-    return mentions
+    return mentions;
   }
 }
 
-module.exports = function (robot) {
-  return new Detector(robot)
-}
+module.exports = function(robot) {
+  return new Detector(robot);
+};

--- a/scripts/documentset/preprocessor/slackapp.js
+++ b/scripts/documentset/preprocessor/slackapp.js
@@ -1,75 +1,75 @@
 // Accept text copied and pasted from the Slack thick-client.
 
-const moment = require('moment-timezone')
-const createMentionDetector = require('./mentions')
-const Line = require('../../models/line')
+const moment = require("moment-timezone");
+const createMentionDetector = require("./mentions");
+const Line = require("../../models/line");
 
 // RegExp snippets for re-use
-const TS = '\\[(\\d{1,2}:\\d{2}( [aApP][mM])?)\\]' // [11:22 AM] *or* [16:00]
+const TS = "\\[(\\d{1,2}:\\d{2}( [aApP][mM])?)\\]"; // [11:22 AM] *or* [16:00]
 
 // RegExps
-const rxWs = /^\s*$/
-const rxNickLine = new RegExp(`^\\s*(\\S+)\\s+${TS}\\s*$`)
-const rxTsLine = new RegExp(`^\\s*${TS}\\s*$`)
-const rxNewMessagesLine = new RegExp(`^\\s*new messages\\s*$`)
+const rxWs = /^\s*$/;
+const rxNickLine = new RegExp(`^\\s*(\\S+)\\s+${TS}\\s*$`);
+const rxTsLine = new RegExp(`^\\s*${TS}\\s*$`);
+const rxNewMessagesLine = new RegExp(`^\\s*new messages\\s*$`);
 
-function parseTs (ts) {
-  const parsed = moment.tz(ts, ['h:mm a', 'H:mm'], true, 'America/New_York')
+function parseTs(ts) {
+  const parsed = moment.tz(ts, ["h:mm a", "H:mm"], true, "America/New_York");
   if (!parsed.isValid()) {
-    throw new Error(`Invalid date: ${ts}`)
+    throw new Error(`Invalid date: ${ts}`);
   }
-  return parsed
+  return parsed;
 }
 
-module.exports = function (robot, text) {
-  let nick, ts, ampm
-  const mentionDetector = createMentionDetector(robot)
+module.exports = function(robot, text) {
+  let nick, ts, ampm;
+  const mentionDetector = createMentionDetector(robot);
 
-  const result = []
-  const speakers = new Set()
-  const mentions = new Set()
+  const result = [];
+  const speakers = new Set();
+  const mentions = new Set();
 
-  const lines = text.split(/\r?\n/)
+  const lines = text.split(/\r?\n/);
   for (let i = 0; i < lines.length; i++) {
-    let body = lines[i]
+    let body = lines[i];
 
     if (rxWs.test(body)) {
-      continue
+      continue;
     }
 
     if (rxNewMessagesLine.test(body)) {
-      continue
+      continue;
     }
 
-    const nickMatch = rxNickLine.exec(body)
+    const nickMatch = rxNickLine.exec(body);
     if (nickMatch) {
-      nick = nickMatch[1].replace(/APP$/, '')
-      ts = parseTs(nickMatch[2])
-      ampm = nickMatch[3]
-      continue
+      nick = nickMatch[1].replace(/APP$/, "");
+      ts = parseTs(nickMatch[2]);
+      ampm = nickMatch[3];
+      continue;
     }
 
-    const tsMatch = rxTsLine.exec(body)
+    const tsMatch = rxTsLine.exec(body);
     if (tsMatch) {
-      ampm = tsMatch[2] || ampm || ''
-      ts = parseTs(tsMatch[1] + ampm)
-      continue
+      ampm = tsMatch[2] || ampm || "";
+      ts = parseTs(tsMatch[1] + ampm);
+      continue;
     }
 
     if (!nick && !ts) {
-      throw new Error('Expected nick and timestamp line first.')
+      throw new Error("Expected nick and timestamp line first.");
     }
 
-    body = body.replace(/\s*\(edited\)$/, '')
+    body = body.replace(/\s*\(edited\)$/, "");
 
     for (const mention of mentionDetector.scan(body)) {
-      mentions.add(mention)
+      mentions.add(mention);
     }
 
-    speakers.add(nick)
+    speakers.add(nick);
 
-    result.push(new Line(ts, nick, body))
+    result.push(new Line(ts, nick, body));
   }
 
-  return { lines: result, speakers, mentions }
-}
+  return {lines: result, speakers, mentions};
+};

--- a/scripts/documentset/preprocessor/verbatim.js
+++ b/scripts/documentset/preprocessor/verbatim.js
@@ -1,11 +1,11 @@
 // Accept text as-is from a command's input. Derive no speaker metadata.
 
-const createMentionDetector = require('./mentions')
-const Line = require('../../models/line')
+const createMentionDetector = require("./mentions");
+const Line = require("../../models/line");
 
-module.exports = function (robot, text) {
-  const mentions = createMentionDetector(robot).scan(text)
-  const lines = text.split(/\r?\n/).map(body => new Line(null, null, body))
+module.exports = function(robot, text) {
+  const mentions = createMentionDetector(robot).scan(text);
+  const lines = text.split(/\r?\n/).map(body => new Line(null, null, body));
 
-  return { lines, speakers: [], mentions }
-}
+  return {lines, speakers: [], mentions};
+};

--- a/scripts/documentset/query.js
+++ b/scripts/documentset/query.js
@@ -1,54 +1,54 @@
 // Convert a raw query string to a PostgreSQL-compatible regular expression.
-module.exports = function (query) {
-  const terms = []
+module.exports = function(query) {
+  const terms = [];
 
-  let i = 0
-  let currentTerm = ''
-  let termTerminator = null
+  let i = 0;
+  let currentTerm = "";
+  let termTerminator = null;
 
-  function appendToTerm (letter) {
+  function appendToTerm(letter) {
     // Escape regular expression metacharacters
-    if ('.+*?^$|()[]\\{}'.indexOf(letter) !== -1) {
-      currentTerm += '\\' + letter
+    if (".+*?^$|()[]\\{}".indexOf(letter) !== -1) {
+      currentTerm += "\\" + letter;
     } else {
-      currentTerm += letter
+      currentTerm += letter;
     }
   }
 
   while (i < query.length) {
-    const letter = query[i]
+    const letter = query[i];
 
     // Backslash escapes
-    if (letter === '\\') {
-      i++
-      appendToTerm(query[i])
+    if (letter === "\\") {
+      i++;
+      appendToTerm(query[i]);
     } else if (termTerminator !== null) {
       // Within a term
       if (termTerminator.test(letter)) {
-        terms.push(currentTerm)
-        currentTerm = ''
-        termTerminator = null
+        terms.push(currentTerm);
+        currentTerm = "";
+        termTerminator = null;
       } else {
-        appendToTerm(letter)
+        appendToTerm(letter);
       }
     } else {
       // Outside of a term
       if (letter === '"') {
-        termTerminator = /"/
+        termTerminator = /"/;
       } else if (letter === "'") {
-        termTerminator = /'/
+        termTerminator = /'/;
       } else if (/\S/.test(letter)) {
-        appendToTerm(letter)
-        termTerminator = /\s/
+        appendToTerm(letter);
+        termTerminator = /\s/;
       }
     }
 
-    i++
+    i++;
   }
 
   if (currentTerm.length > 0) {
-    terms.push(currentTerm)
+    terms.push(currentTerm);
   }
 
-  return terms
-}
+  return terms;
+};

--- a/scripts/documentset/storage.js
+++ b/scripts/documentset/storage.js
@@ -1,33 +1,34 @@
 // PostgreSQL-backed storage for various kinds of quotes.
 
-const pg = require('pg-promise')()
-const queryParser = require('./query')
+const pg = require("pg-promise")();
+const queryParser = require("./query");
 
-const BEFORE = Symbol('before')
-const AFTER = Symbol('after')
-const RANDOM = Symbol('random')
-const LATEST = Symbol('latest')
+const BEFORE = Symbol("before");
+const AFTER = Symbol("after");
+const RANDOM = Symbol("random");
+const LATEST = Symbol("latest");
 
 class Storage {
-  constructor (options) {
+  constructor(options) {
     if (options.db) {
-      this.db = options.db
+      this.db = options.db;
     } else if (options.databaseUrl) {
-      this.db = pg(options.databaseUrl)
+      this.db = pg(options.databaseUrl);
     } else {
-      throw new Error('Either db or databaseUrl must be provided')
+      throw new Error("Either db or databaseUrl must be provided");
     }
 
-    this.columnSets = new Map()
+    this.columnSets = new Map();
   }
 
-  async connectDocumentSet (documentSet) {
+  async connectDocumentSet(documentSet) {
     const values = {
       documentTable: documentSet.documentTableName(),
-      attributeTable: documentSet.attributeTableName()
-    }
+      attributeTable: documentSet.attributeTableName(),
+    };
 
-    await this.db.none(`
+    await this.db.none(
+      `
       CREATE TABLE IF NOT EXISTS $<documentTable:name> (
         id SERIAL PRIMARY KEY,
         created TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
@@ -35,9 +36,12 @@ class Storage {
         submitter TEXT,
         body TEXT NOT NULL
       )
-    `, values)
+    `,
+      values
+    );
 
-    await this.db.none(`
+    await this.db.none(
+      `
       CREATE TABLE IF NOT EXISTS $<attributeTable:name> (
         id SERIAL PRIMARY KEY,
         document_id INTEGER REFERENCES $<documentTable:name>
@@ -45,92 +49,105 @@ class Storage {
         kind TEXT NOT NULL,
         value TEXT NOT NULL
       )
-    `, values)
+    `,
+      values
+    );
 
     const columnSet = {
       attributeInsert: new pg.helpers.ColumnSet(
-        ['document_id', 'kind', 'value'],
-        { table: values.attributeTable }
-      )
-    }
+        ["document_id", "kind", "value"],
+        {table: values.attributeTable}
+      ),
+    };
 
-    this.columnSets.set(documentSet, columnSet)
+    this.columnSets.set(documentSet, columnSet);
   }
 
-  async insertDocument (documentSet, submitter, body, attributes) {
+  async insertDocument(documentSet, submitter, body, attributes) {
     const values = {
       documentTable: documentSet.documentTableName(),
       submitter,
-      body
-    }
+      body,
+    };
 
-    const row = await this.db.one(`
+    const row = await this.db.one(
+      `
       INSERT INTO $<documentTable:name>
       (submitter, body)
       VALUES ($<submitter>, $<body>)
       RETURNING id, created, updated
-    `, values)
+    `,
+      values
+    );
 
-    const docResult = Object.assign({ submitter, body, attributes: [] }, row)
+    const docResult = Object.assign({submitter, body, attributes: []}, row);
     if (attributes.length === 0) {
-      return Promise.resolve([])
+      return Promise.resolve([]);
     }
 
-    const linkedAttributes = attributes
-      .map(attribute => Object.assign({ document_id: row.id }, attribute))
+    const linkedAttributes = attributes.map(attribute =>
+      Object.assign({document_id: row.id}, attribute)
+    );
 
-    const cs = this.columnSets.get(documentSet).attributeInsert
-    const query = pg.helpers.insert(linkedAttributes, cs) +
-      'RETURNING id'
+    const cs = this.columnSets.get(documentSet).attributeInsert;
+    const query = pg.helpers.insert(linkedAttributes, cs) + "RETURNING id";
 
-    const attrRows = await this.db.many(query)
+    const attrRows = await this.db.many(query);
     for (let i = 0; i < attrRows.length; i++) {
-      const original = attributes[i]
-      const row = attrRows[i]
-      const full = Object.assign({}, row, original)
+      const original = attributes[i];
+      const row = attrRows[i];
+      const full = Object.assign({}, row, original);
 
-      docResult.attributes.push(full)
+      docResult.attributes.push(full);
     }
 
-    return docResult
+    return docResult;
   }
 
-  singleDocumentMatching (documentSet, attributes, query, order) {
-    const documentTableName = documentSet.documentTableName()
-    const attributeTableName = documentSet.attributeTableName()
+  singleDocumentMatching(documentSet, attributes, query, order) {
+    const documentTableName = documentSet.documentTableName();
+    const attributeTableName = documentSet.attributeTableName();
 
-    const hasAttributes = Object.keys(attributes).length > 0
-    const hasQuery = query && /\s*\S/.test(query)
+    const hasAttributes = Object.keys(attributes).length > 0;
+    const hasQuery = query && /\s*\S/.test(query);
 
-    let where = ''
-    let queryClause = ''
-    let separator = ''
-    let attrClause = ''
-    const parameters = [documentTableName, attributeTableName]
+    let where = "";
+    let queryClause = "";
+    let separator = "";
+    let attrClause = "";
+    const parameters = [documentTableName, attributeTableName];
 
     if (hasQuery || hasAttributes) {
-      where = 'WHERE'
+      where = "WHERE";
     }
 
     if (hasQuery) {
-      const { clause, parameters: queryParameters } = createQueryClause(query, 'body', parameters.length + 1)
-      queryClause = clause
-      parameters.push(...queryParameters)
+      const {clause, parameters: queryParameters} = createQueryClause(
+        query,
+        "body",
+        parameters.length + 1
+      );
+      queryClause = clause;
+      parameters.push(...queryParameters);
     }
 
     if (hasQuery && hasAttributes) {
-      separator = 'AND'
+      separator = "AND";
     }
 
     if (hasAttributes) {
-      const { query, parameters: attrParameters } = createAttributeQuery(attributes, 2, parameters.length + 1)
-      attrClause = `id IN (${query})`
-      parameters.push(...attrParameters)
+      const {query, parameters: attrParameters} = createAttributeQuery(
+        attributes,
+        2,
+        parameters.length + 1
+      );
+      attrClause = `id IN (${query})`;
+      parameters.push(...attrParameters);
     }
 
-    let orderClause = ''
-    if (order === RANDOM) orderClause = 'ORDER BY RANDOM()'
-    if (order === LATEST) orderClause = 'ORDER BY created DESC'
+    let orderClause = "";
+    if (order === RANDOM) orderClause = "ORDER BY RANDOM()";
+    if (order === LATEST) orderClause = "ORDER BY created DESC";
 
     const sql = `
       SELECT id, created, updated, submitter, body
@@ -138,167 +155,201 @@ class Storage {
       ${where} ${queryClause} ${separator} ${attrClause}
       ${orderClause}
       LIMIT 1
-    `
+    `;
 
-    return this.db.oneOrNone(sql, parameters)
+    return this.db.oneOrNone(sql, parameters);
   }
 
-  allDocumentsMatching (documentSet, attributes, query, first = null, cursor = null) {
-    const documentTableName = documentSet.documentTableName()
-    const attributeTableName = documentSet.attributeTableName()
+  allDocumentsMatching(
+    documentSet,
+    attributes,
+    query,
+    first = null,
+    cursor = null
+  ) {
+    const documentTableName = documentSet.documentTableName();
+    const attributeTableName = documentSet.attributeTableName();
 
-    const hasAttributes = Object.keys(attributes).length > 0
-    const hasQuery = /\s*\S/.test(query)
-    const hasCursor = cursor !== null
-    const hasFirst = first !== null
+    const hasAttributes = Object.keys(attributes).length > 0;
+    const hasQuery = /\s*\S/.test(query);
+    const hasCursor = cursor !== null;
+    const hasFirst = first !== null;
 
-    const clauses = []
-    const parameters = [documentTableName, attributeTableName]
+    const clauses = [];
+    const parameters = [documentTableName, attributeTableName];
 
     if (hasQuery) {
-      const { clause, parameters: queryParameters } = createQueryClause(query, 'body', parameters.length + 1)
-      clauses.push(clause)
-      parameters.push(...queryParameters)
+      const {clause, parameters: queryParameters} = createQueryClause(
+        query,
+        "body",
+        parameters.length + 1
+      );
+      clauses.push(clause);
+      parameters.push(...queryParameters);
     }
 
     if (hasAttributes) {
-      const { query, parameters: attrParameters } = createAttributeQuery(attributes, 2, parameters.length + 1)
-      clauses.push(`id IN (${query})`)
-      parameters.push(...attrParameters)
+      const {query, parameters: attrParameters} = createAttributeQuery(
+        attributes,
+        2,
+        parameters.length + 1
+      );
+      clauses.push(`id IN (${query})`);
+      parameters.push(...attrParameters);
     }
 
     if (hasCursor) {
-      clauses.push(`id > $${parameters.length + 1}`)
-      parameters.push(cursor)
+      clauses.push(`id > $${parameters.length + 1}`);
+      parameters.push(cursor);
     }
 
-    const where = clauses.length > 0 ? 'WHERE' : ''
-    let limit = ''
+    const where = clauses.length > 0 ? "WHERE" : "";
+    let limit = "";
     if (hasFirst) {
-      limit = `LIMIT $${parameters.length + 1}`
-      parameters.push(first)
+      limit = `LIMIT $${parameters.length + 1}`;
+      parameters.push(first);
     }
 
     const sql = `
       SELECT id, created, updated, submitter, body
       FROM $1:name
-      ${where} ${clauses.join(' AND ')}
+      ${where} ${clauses.join(" AND ")}
       ORDER BY id
       ${limit}
-    `
+    `;
 
-    return this.db.any(sql, parameters)
+    return this.db.any(sql, parameters);
   }
 
-  hasDocumentsMatching (documentSet, attributes, query, cursor, direction) {
-    const documentTableName = documentSet.documentTableName()
-    const attributeTableName = documentSet.attributeTableName()
+  hasDocumentsMatching(documentSet, attributes, query, cursor, direction) {
+    const documentTableName = documentSet.documentTableName();
+    const attributeTableName = documentSet.attributeTableName();
 
-    const hasAttributes = Object.keys(attributes).length > 0
-    const hasQuery = /\s*\S/.test(query)
+    const hasAttributes = Object.keys(attributes).length > 0;
+    const hasQuery = /\s*\S/.test(query);
 
-    const clauses = []
-    const parameters = [documentTableName, attributeTableName]
+    const clauses = [];
+    const parameters = [documentTableName, attributeTableName];
 
     if (hasQuery) {
-      const { clause, parameters: queryParameters } = createQueryClause(query, 'body', parameters.length + 1)
-      clauses.push(clause)
-      parameters.push(...queryParameters)
+      const {clause, parameters: queryParameters} = createQueryClause(
+        query,
+        "body",
+        parameters.length + 1
+      );
+      clauses.push(clause);
+      parameters.push(...queryParameters);
     }
 
     if (hasAttributes) {
-      const { query, parameters: attrParameters } = createAttributeQuery(attributes, 2, parameters.length + 1)
-      clauses.push(`id IN (${query})`)
-      parameters.push(...attrParameters)
+      const {query, parameters: attrParameters} = createAttributeQuery(
+        attributes,
+        2,
+        parameters.length + 1
+      );
+      clauses.push(`id IN (${query})`);
+      parameters.push(...attrParameters);
     }
 
-    const operator = direction === BEFORE ? '<' : '>'
-    clauses.push(`id ${operator} $${parameters.length + 1}`)
-    parameters.push(cursor)
+    const operator = direction === BEFORE ? "<" : ">";
+    clauses.push(`id ${operator} $${parameters.length + 1}`);
+    parameters.push(cursor);
 
     const sql = `
       SELECT EXISTS(
         SELECT 1
         FROM $1:name
-        WHERE ${clauses.join(' AND ')}
+        WHERE ${clauses.join(" AND ")}
       ) AS exists
-    `
+    `;
 
-    return this.db.one(sql, parameters, row => row.exists)
+    return this.db.one(sql, parameters, row => row.exists);
   }
 
-  countDocumentsMatching (documentSet, attributes, query) {
-    const documentTableName = documentSet.documentTableName()
-    const attributeTableName = documentSet.attributeTableName()
+  countDocumentsMatching(documentSet, attributes, query) {
+    const documentTableName = documentSet.documentTableName();
+    const attributeTableName = documentSet.attributeTableName();
 
-    const hasAttributes = Object.keys(attributes).length > 0
-    const hasQuery = query.trim() !== ''
+    const hasAttributes = Object.keys(attributes).length > 0;
+    const hasQuery = query.trim() !== "";
 
     // Avoid an unnecessary join for attribute-only queries
     if (!hasQuery && hasAttributes) {
-      const { query, parameters: attrParameters } = createAttributeQuery(attributes, 1, 2)
-      const sql = `SELECT COUNT(*) AS count FROM (${query}) AS attrs`
-      const parameters = [attributeTableName, ...attrParameters]
+      const {query, parameters: attrParameters} = createAttributeQuery(
+        attributes,
+        1,
+        2
+      );
+      const sql = `SELECT COUNT(*) AS count FROM (${query}) AS attrs`;
+      const parameters = [attributeTableName, ...attrParameters];
 
-      return this.db.one(sql, parameters)
+      return this.db.one(sql, parameters);
     }
 
-    let where = ''
-    let queryClause = ''
-    let separator = ''
-    let attrClause = ''
-    const parameters = [documentTableName, attributeTableName]
+    let where = "";
+    let queryClause = "";
+    let separator = "";
+    let attrClause = "";
+    const parameters = [documentTableName, attributeTableName];
 
     if (hasQuery || hasAttributes) {
-      where = 'WHERE'
+      where = "WHERE";
     }
 
     if (hasQuery) {
-      const { clause, parameters: queryParameters } = createQueryClause(query, 'body', parameters.length + 1)
-      queryClause = clause
-      parameters.push(...queryParameters)
+      const {clause, parameters: queryParameters} = createQueryClause(
+        query,
+        "body",
+        parameters.length + 1
+      );
+      queryClause = clause;
+      parameters.push(...queryParameters);
     }
 
     if (hasQuery && hasAttributes) {
-      separator = 'AND'
+      separator = "AND";
     }
 
     if (hasAttributes) {
-      const { query, parameters: attrParameters } = createAttributeQuery(attributes, 2, parameters.length + 1)
-      attrClause = `id IN (${query})`
-      parameters.push(...attrParameters)
+      const {query, parameters: attrParameters} = createAttributeQuery(
+        attributes,
+        2,
+        parameters.length + 1
+      );
+      attrClause = `id IN (${query})`;
+      parameters.push(...attrParameters);
     }
 
     const sql = `
       SELECT COUNT(*) AS count
       FROM $1:name
       ${where} ${queryClause} ${separator} ${attrClause}
-    `
+    `;
 
-    return this.db.one(sql, parameters)
+    return this.db.one(sql, parameters);
   }
 
-  loadDocumentAttributes (documentSet, documents) {
-    const attributeTableName = documentSet.attributeTableName()
-    const ids = documents.map(doc => doc.id)
-    const parameters = { attributeTableName, ids }
+  loadDocumentAttributes(documentSet, documents) {
+    const attributeTableName = documentSet.attributeTableName();
+    const ids = documents.map(doc => doc.id);
+    const parameters = {attributeTableName, ids};
 
     if (documents.length === 0) {
-      return []
+      return [];
     }
 
     const sql = `
       SELECT id, kind, value, document_id
       FROM $<attributeTableName:name>
       WHERE document_id IN ($<ids:csv>)
-    `
+    `;
 
-    return this.db.any(sql, parameters)
+    return this.db.any(sql, parameters);
   }
 
-  attributeStats (documentSet, attributeKinds) {
-    const attributeTableName = documentSet.attributeTableName()
-    const parameters = [attributeTableName, attributeKinds]
+  attributeStats(documentSet, attributeKinds) {
+    const attributeTableName = documentSet.attributeTableName();
+    const parameters = [attributeTableName, attributeKinds];
 
     const sql = `
       SELECT kind, value, COUNT(*) AS count
@@ -306,85 +357,96 @@ class Storage {
       WHERE kind IN ($2:csv)
       GROUP BY kind, value
       HAVING COUNT(*) > 0
-    `
+    `;
 
-    return this.db.any(sql, parameters)
+    return this.db.any(sql, parameters);
   }
 
-  deleteDocumentsMatching (documentSet, attributes) {
-    const documentTableName = documentSet.documentTableName()
-    const attributeTableName = documentSet.attributeTableName()
+  deleteDocumentsMatching(documentSet, attributes) {
+    const documentTableName = documentSet.documentTableName();
+    const attributeTableName = documentSet.attributeTableName();
 
     if (attributes.length === 0) {
-      return this.destroyDocumentSet(documentSet)
+      return this.destroyDocumentSet(documentSet);
     }
 
-    const attr = createAttributeQuery(attributes, 2, 3)
-    const query = `DELETE FROM $1:name WHERE id IN (${attr.query})`
-    const parameters = [documentTableName, attributeTableName, ...attr.parameters]
+    const attr = createAttributeQuery(attributes, 2, 3);
+    const query = `DELETE FROM $1:name WHERE id IN (${attr.query})`;
+    const parameters = [
+      documentTableName,
+      attributeTableName,
+      ...attr.parameters,
+    ];
 
-    return this.db.none(query, parameters)
+    return this.db.none(query, parameters);
   }
 
-  async destroyDocumentSet (documentSet) {
+  async destroyDocumentSet(documentSet) {
     const values = {
       documentTable: documentSet.documentTableName(),
-      attributeTable: documentSet.attributeTableName()
-    }
+      attributeTable: documentSet.attributeTableName(),
+    };
 
-    await this.db.none('DROP TABLE IF EXISTS $<attributeTable:name>', values)
-    await this.db.none('DROP TABLE IF EXISTS $<documentTable:name>', values)
-    this.columnSets.delete(documentSet)
+    await this.db.none("DROP TABLE IF EXISTS $<attributeTable:name>", values);
+    await this.db.none("DROP TABLE IF EXISTS $<documentTable:name>", values);
+    this.columnSets.delete(documentSet);
   }
 
-  async truncateDocumentSet (documentSet) {
+  async truncateDocumentSet(documentSet) {
     const values = {
       documentTable: documentSet.documentTableName(),
-      attributeTable: documentSet.attributeTableName()
-    }
+      attributeTable: documentSet.attributeTableName(),
+    };
 
-    await this.db.none('TRUNCATE TABLE $<attributeTable:name>, $<documentTable:name>', values)
+    await this.db.none(
+      "TRUNCATE TABLE $<attributeTable:name>, $<documentTable:name>",
+      values
+    );
   }
 }
 
-function createQueryClause (quoteSrc, fieldName, placeholderBase) {
-  const terms = queryParser(quoteSrc)
+function createQueryClause(quoteSrc, fieldName, placeholderBase) {
+  const terms = queryParser(quoteSrc);
   return {
     clause: terms
       .map((term, index) => `${fieldName} ~* $${placeholderBase + index}`)
-      .join(' AND '),
-    parameters: terms
-  }
+      .join(" AND "),
+    parameters: terms,
+  };
 }
 
-function createAttributeQuery (attributes, attrTablePlaceholder, placeholderBase) {
-  const parameters = []
+function createAttributeQuery(
+  attributes,
+  attrTablePlaceholder,
+  placeholderBase
+) {
+  const parameters = [];
 
-  const kinds = Object.keys(attributes)
-  const subSelects = []
-  let placeholder = placeholderBase
+  const kinds = Object.keys(attributes);
+  const subSelects = [];
+  let placeholder = placeholderBase;
 
   for (let i = 0; i < kinds.length; i++) {
-    const attrKind = kinds[i]
-    const attrValues = attributes[attrKind]
+    const attrKind = kinds[i];
+    const attrValues = attributes[attrKind];
 
-    const attrKindPlaceholder = placeholder
-    parameters.push(attrKind)
-    placeholder++
+    const attrKindPlaceholder = placeholder;
+    parameters.push(attrKind);
+    placeholder++;
 
     for (let j = 0; j < attrValues.length; j++) {
       const subSelect = `
         SELECT document_id FROM $${attrTablePlaceholder}:name
         WHERE kind = $${attrKindPlaceholder} AND value = $${placeholder}
-      `
-      parameters.push(attrValues[j])
-      placeholder++
+      `;
+      parameters.push(attrValues[j]);
+      placeholder++;
 
-      subSelects.push(subSelect)
+      subSelects.push(subSelect);
     }
   }
 
-  return { query: subSelects.join(' INTERSECT '), parameters }
+  return {query: subSelects.join(" INTERSECT "), parameters};
 }
 
 module.exports = {
@@ -392,5 +454,5 @@ module.exports = {
   BEFORE,
   AFTER,
   RANDOM,
-  LATEST
-}
+  LATEST,
+};

--- a/scripts/helpers/index.js
+++ b/scripts/helpers/index.js
@@ -1,56 +1,56 @@
 // Grab-bag of utility functions.
 
-const yargs = require('yargs/yargs')
+const yargs = require("yargs/yargs");
 
-function atRandom (list) {
-  const max = list.length - 1
-  const index = Math.floor(Math.random() * (max + 1))
-  return list[index]
+function atRandom(list) {
+  const max = list.length - 1;
+  const index = Math.floor(Math.random() * (max + 1));
+  return list[index];
 }
 
 const NullDataStore = {
-  getChannelGroupOrDMById () {
-    return null
+  getChannelGroupOrDMById() {
+    return null;
   },
 
-  getChannelByName () {
-    return null
-  }
-}
+  getChannelByName() {
+    return null;
+  },
+};
 
-function getDataStore (robot) {
-  const adapter = robot.adapter
-  const client = adapter.client
-  if (!client) return NullDataStore
-  const rtm = client.rtm
-  if (!rtm) return NullDataStore
-  const dataStore = rtm.dataStore
-  if (!dataStore) return NullDataStore
-  return dataStore
+function getDataStore(robot) {
+  const adapter = robot.adapter;
+  const client = adapter.client;
+  if (!client) return NullDataStore;
+  const rtm = client.rtm;
+  if (!rtm) return NullDataStore;
+  const dataStore = rtm.dataStore;
+  if (!dataStore) return NullDataStore;
+  return dataStore;
 }
 
 // Parse command options provided with shell-like syntax
 
-function parseArguments (msg, argline, fn) {
-  const y = fn(yargs().version(false))
+function parseArguments(msg, argline, fn) {
+  const y = fn(yargs().version(false));
   return new Promise(resolve => {
     y.parse(argline, (err, argv, output) => {
       if (err) {
-        msg.reply(`:boom: You broke it!\n${msg}\n${this.yargs.help()}`)
-        resolve(null)
+        msg.reply(`:boom: You broke it!\n${msg}\n${this.yargs.help()}`);
+        resolve(null);
       }
 
       if (output) {
-        msg.reply(output)
+        msg.reply(output);
       }
 
-      resolve(argv)
-    })
-  })
+      resolve(argv);
+    });
+  });
 }
 
 module.exports = {
   atRandom,
   getDataStore,
-  parseArguments
-}
+  parseArguments,
+};

--- a/scripts/models/buffer.js
+++ b/scripts/models/buffer.js
@@ -1,81 +1,81 @@
 // Per-user stash of Lines.
 
-const Line = require('./line')
+const Line = require("./line");
 
-const BUFFERS = new Map()
+const BUFFERS = new Map();
 
 class Buffer {
-  constructor (robot, ownerId) {
-    this.robot = robot
-    this.ownerId = ownerId
+  constructor(robot, ownerId) {
+    this.robot = robot;
+    this.ownerId = ownerId;
 
-    const serialized = this.robot.brain.get(`buffer:${this.ownerId}`)
+    const serialized = this.robot.brain.get(`buffer:${this.ownerId}`);
     if (serialized) {
-      this.contents = serialized.map(each => Line.deserialize(each))
+      this.contents = serialized.map(each => Line.deserialize(each));
     } else {
-      this.contents = []
+      this.contents = [];
     }
   }
 
-  isValidIndex (index) {
-    return index >= 0 && index < this.contents.length
+  isValidIndex(index) {
+    return index >= 0 && index < this.contents.length;
   }
 
-  append (lines) {
-    this.contents.push(...lines)
-    this.save()
+  append(lines) {
+    this.contents.push(...lines);
+    this.save();
   }
 
-  remove (index) {
-    this.contents.splice(index, 1)
-    this.save()
+  remove(index) {
+    this.contents.splice(index, 1);
+    this.save();
   }
 
-  replace (index, newLines) {
-    this.contents.splice(index, 1, ...newLines)
-    this.save()
+  replace(index, newLines) {
+    this.contents.splice(index, 1, ...newLines);
+    this.save();
   }
 
-  clear () {
-    this.contents = []
-    this.save()
+  clear() {
+    this.contents = [];
+    this.save();
   }
 
-  show () {
+  show() {
     if (this.contents.length === 0) {
-      return 'Your buffer is currently empty.'
+      return "Your buffer is currently empty.";
     }
 
-    return this.contents.map((line, i) => `_(${i})_ ${line}`).join('\n')
+    return this.contents.map((line, i) => `_(${i})_ ${line}`).join("\n");
   }
 
-  commit () {
-    const prior = this.contents
-    this.contents = []
-    this.save()
-    return prior
+  commit() {
+    const prior = this.contents;
+    this.contents = [];
+    this.save();
+    return prior;
   }
 
-  save () {
-    const serialized = this.contents.map(line => line.serialize())
-    this.robot.brain.set(`buffer:${this.ownerId}`, serialized)
+  save() {
+    const serialized = this.contents.map(line => line.serialize());
+    this.robot.brain.set(`buffer:${this.ownerId}`, serialized);
   }
 }
 
-function forUser (robot, uid) {
-  const existing = BUFFERS.get(uid)
+function forUser(robot, uid) {
+  const existing = BUFFERS.get(uid);
   if (existing) {
-    return existing
+    return existing;
   }
 
-  const created = new Buffer(robot, uid)
-  BUFFERS.set(uid, created)
-  return created
+  const created = new Buffer(robot, uid);
+  BUFFERS.set(uid, created);
+  return created;
 }
 
-function clear () {
-  BUFFERS.clear()
+function clear() {
+  BUFFERS.clear();
 }
 
-exports.forUser = forUser
-exports.clear = clear
+exports.forUser = forUser;
+exports.clear = clear;

--- a/scripts/models/cache.js
+++ b/scripts/models/cache.js
@@ -1,140 +1,140 @@
 // Cache recently spoken lines within a given channel. Persist the cache
 // within the brain.
 
-const moment = require('moment-timezone')
-const Line = require('./line')
+const moment = require("moment-timezone");
+const Line = require("./line");
 
-const MAX_CACHE_SIZE = 200
-const CACHES = new Map()
+const MAX_CACHE_SIZE = 200;
+const CACHES = new Map();
 
 class Cache {
-  static known (robot) {
-    return robot.brain.get('buffer-cache-known') || []
+  static known(robot) {
+    return robot.brain.get("buffer-cache-known") || [];
   }
 
-  static remember (robot, channel) {
-    const existing = Cache.known(robot)
+  static remember(robot, channel) {
+    const existing = Cache.known(robot);
     if (!existing.includes(channel)) {
-      robot.brain.set('buffer-cache-known', existing.concat([channel]))
+      robot.brain.set("buffer-cache-known", existing.concat([channel]));
     }
   }
 
-  static storageForChannel (robot, channel) {
-    return robot.brain.get(`buffer-cache:${channel}`)
+  static storageForChannel(robot, channel) {
+    return robot.brain.get(`buffer-cache:${channel}`);
   }
 
-  constructor (robot, channel) {
-    this.robot = robot
-    this.channel = channel
+  constructor(robot, channel) {
+    this.robot = robot;
+    this.channel = channel;
 
-    const serialized = Cache.storageForChannel(this.robot, this.channel)
+    const serialized = Cache.storageForChannel(this.robot, this.channel);
     if (serialized === null) {
-      this.lines = []
+      this.lines = [];
     } else {
-      this.lines = serialized.map(each => Line.deserialize(each))
+      this.lines = serialized.map(each => Line.deserialize(each));
     }
 
-    Cache.remember(this.robot, this.channel)
+    Cache.remember(this.robot, this.channel);
   }
 
-  append (msg, ts = undefined) {
-    const now = ts || moment.tz('America/New_York')
-    const isAction = msg.message.subtype === 'me_message'
+  append(msg, ts = undefined) {
+    const now = ts || moment.tz("America/New_York");
+    const isAction = msg.message.subtype === "me_message";
     const toAdd = msg.message.text.split(/\n/).map(sourceLine => {
       return new Line(
         now,
         msg.message.user.name,
         isAction ? `_${sourceLine}_` : sourceLine
-      )
-    })
-    toAdd.reverse()
+      );
+    });
+    toAdd.reverse();
 
-    this.lines.unshift(...toAdd)
-    this.lines = this.lines.slice(0, MAX_CACHE_SIZE)
+    this.lines.unshift(...toAdd);
+    this.lines = this.lines.slice(0, MAX_CACHE_SIZE);
 
-    const serialized = this.lines.map(line => line.serialize())
-    this.robot.brain.set(`buffer-cache:${this.channel}`, serialized)
-    return this
+    const serialized = this.lines.map(line => line.serialize());
+    this.robot.brain.set(`buffer-cache:${this.channel}`, serialized);
+    return this;
   }
 
-  mostRecent () {
-    return this.lines[0]
+  mostRecent() {
+    return this.lines[0];
   }
 
-  earliest () {
-    return this.lines.slice(-1)[0]
+  earliest() {
+    return this.lines.slice(-1)[0];
   }
 
-  mostRecentMatch (pattern) {
-    return this.lines.find(line => pattern.matches(line))
+  mostRecentMatch(pattern) {
+    return this.lines.find(line => pattern.matches(line));
   }
 
-  between (startPattern, endPattern) {
-    const results = []
-    let inMatch = false
+  between(startPattern, endPattern) {
+    const results = [];
+    let inMatch = false;
 
     for (let i = 0; i < this.lines.length; i++) {
-      const line = this.lines[i]
+      const line = this.lines[i];
 
       if (inMatch) {
-        results.push(line)
+        results.push(line);
         if (startPattern.matches(line)) {
-          inMatch = false
-          break
+          inMatch = false;
+          break;
         }
       } else if (endPattern.matches(line)) {
-        results.push(line)
-        inMatch = true
+        results.push(line);
+        inMatch = true;
       }
     }
 
     if (inMatch || results.length === 0) {
-      return undefined
+      return undefined;
     }
 
-    results.reverse()
-    return results
+    results.reverse();
+    return results;
   }
 }
 
-function prepopulate (robot) {
-  if (CACHES.size !== 0) return
+function prepopulate(robot) {
+  if (CACHES.size !== 0) return;
 
   // Pre-populate known channels.
   for (const former of Cache.known(robot)) {
-    const resurrected = new Cache(robot, former)
-    CACHES.set(former, resurrected)
+    const resurrected = new Cache(robot, former);
+    CACHES.set(former, resurrected);
   }
 }
 
-function cacheForChannel (robot, channel, create = true) {
-  prepopulate(robot)
+function cacheForChannel(robot, channel, create = true) {
+  prepopulate(robot);
 
-  const existing = CACHES.get(channel)
+  const existing = CACHES.get(channel);
   if (existing) {
-    return existing
+    return existing;
   }
 
   if (!create && !Cache.storageForChannel(robot, channel)) {
-    return null
+    return null;
   }
 
-  const created = new Cache(robot, channel)
-  CACHES.set(channel, created)
-  return created
+  const created = new Cache(robot, channel);
+  CACHES.set(channel, created);
+  return created;
 }
 
-function clear () {
-  CACHES.clear()
+function clear() {
+  CACHES.clear();
 }
 
-function known (robot) {
-  prepopulate(robot)
+function known(robot) {
+  prepopulate(robot);
 
-  return Array.from(CACHES.keys())
+  return Array.from(CACHES.keys());
 }
 
-exports.MAX_SIZE = MAX_CACHE_SIZE
-exports.forChannel = cacheForChannel
-exports.clear = clear
-exports.known = known
+exports.MAX_SIZE = MAX_CACHE_SIZE;
+exports.forChannel = cacheForChannel;
+exports.clear = clear;
+exports.known = known;

--- a/scripts/models/calendar.js
+++ b/scripts/models/calendar.js
@@ -1,44 +1,44 @@
-const uuid = require('uuid/v1')
+const uuid = require("uuid/v1");
 
 class CalendarMap {
-  static inRobot (robot) {
+  static inRobot(robot) {
     if (!this.instance || this.instance.robot !== robot) {
-      this.instance = new CalendarMap(robot)
+      this.instance = new CalendarMap(robot);
     }
-    return this.instance
+    return this.instance;
   }
 
-  constructor (robot) {
-    this.robot = robot
-    this.calendars = new Map(robot.brain.get('hubot-plan:ical') || [])
+  constructor(robot) {
+    this.robot = robot;
+    this.calendars = new Map(robot.brain.get("hubot-plan:ical") || []);
   }
 
-  getCalendar (userId, userTz) {
-    let existing = this.calendars.get(userId)
+  getCalendar(userId, userTz) {
+    let existing = this.calendars.get(userId);
     if (!existing) {
-      const calendarId = uuid()
-      this.calendars.set(userId, { calendarId, userTz })
-      this.robot.brain.set('hubot-plan:ical', Array.from(this.calendars))
-      return calendarId
+      const calendarId = uuid();
+      this.calendars.set(userId, {calendarId, userTz});
+      this.robot.brain.set("hubot-plan:ical", Array.from(this.calendars));
+      return calendarId;
     } else if (existing.userTz !== userTz) {
-      this.calendars.set(userId, { calendarId: existing.calendarId, userTz })
-      this.robot.brain.set('hubot-plan:ical', Array.from(this.calendars))
-      return existing.calendarId
+      this.calendars.set(userId, {calendarId: existing.calendarId, userTz});
+      this.robot.brain.set("hubot-plan:ical", Array.from(this.calendars));
+      return existing.calendarId;
     } else {
-      return existing.calendarId
+      return existing.calendarId;
     }
   }
 
-  isValid (calendarId) {
+  isValid(calendarId) {
     for (const existing of this.calendars.values()) {
       if (existing.calendarId === calendarId) {
-        return true
+        return true;
       }
     }
-    return false
+    return false;
   }
 }
 
 module.exports = {
-  CalendarMap
-}
+  CalendarMap,
+};

--- a/scripts/models/emoji.js
+++ b/scripts/models/emoji.js
@@ -1,56 +1,56 @@
 // 1 hour
-const MAX_AGE = 60 * 60 * 1000
+const MAX_AGE = 60 * 60 * 1000;
 
 class EmojiCache {
-  constructor (robot) {
-    this.robot = robot
-    this.refreshPromise = null
-    this.resolveRefreshPromise = () => {}
+  constructor(robot) {
+    this.robot = robot;
+    this.refreshPromise = null;
+    this.resolveRefreshPromise = () => {};
   }
 
-  async get (emojiName) {
-    let payload = this.robot.brain.get('slack:emoji')
+  async get(emojiName) {
+    let payload = this.robot.brain.get("slack:emoji");
 
     if (!payload) {
-      await this.refresh()
-      payload = this.robot.brain.get('slack:emoji')
+      await this.refresh();
+      payload = this.robot.brain.get("slack:emoji");
     }
 
     if (payload && Date.now() - payload.age >= MAX_AGE) {
-      this.refresh()
+      this.refresh();
     }
 
     if (!payload) {
-      payload = { emoji: {} }
+      payload = {emoji: {}};
     }
 
-    return payload.emoji[emojiName] || null
+    return payload.emoji[emojiName] || null;
   }
 
-  async refresh () {
-    const client = this.robot.adapter.client
+  async refresh() {
+    const client = this.robot.adapter.client;
     if (!client || !client.web || !client.web.emoji || !client.web.emoji.list) {
-      return
+      return;
     }
 
     if (this.refreshPromise) {
-      await this.refreshPromise
-      return
+      await this.refreshPromise;
+      return;
     }
 
     this.refreshPromise = new Promise(resolve => {
-      this.resolveRefreshPromise = resolve
-    })
+      this.resolveRefreshPromise = resolve;
+    });
 
-    const payload = await client.web.emoji.list()
-    payload.age = Date.now()
-    this.robot.brain.set('slack:emoji', payload)
-    this.resolveRefreshPromise()
+    const payload = await client.web.emoji.list();
+    payload.age = Date.now();
+    this.robot.brain.set("slack:emoji", payload);
+    this.resolveRefreshPromise();
   }
 }
 
-function emojiCacheFor (robot) {
-  return new EmojiCache(robot)
+function emojiCacheFor(robot) {
+  return new EmojiCache(robot);
 }
 
-module.exports = { emojiCacheFor }
+module.exports = {emojiCacheFor};

--- a/scripts/models/line.js
+++ b/scripts/models/line.js
@@ -1,44 +1,44 @@
-const moment = require('moment-timezone')
-const uuid = require('uuid/v1')
+const moment = require("moment-timezone");
+const uuid = require("uuid/v1");
 
 class Line {
-  constructor (timestamp, speaker, text, id = null) {
-    this.timestamp = timestamp
-    this.speaker = speaker
-    this.text = text
+  constructor(timestamp, speaker, text, id = null) {
+    this.timestamp = timestamp;
+    this.speaker = speaker;
+    this.text = text;
 
-    this.id = id || uuid()
+    this.id = id || uuid();
   }
 
-  static deserialize (object) {
+  static deserialize(object) {
     return new Line(
-      moment.unix(object.timestamp).tz('America/New_York'),
+      moment.unix(object.timestamp).tz("America/New_York"),
       object.speaker,
       object.text,
       object.id
-    )
+    );
   }
 
-  isRaw () {
-    return this.speaker === undefined || this.speaker === null
+  isRaw() {
+    return this.speaker === undefined || this.speaker === null;
   }
 
-  toString () {
+  toString() {
     if (this.isRaw()) {
-      return this.text
+      return this.text;
     }
 
-    return `${this.speaker}: ${this.text}`
+    return `${this.speaker}: ${this.text}`;
   }
 
-  serialize () {
+  serialize() {
     return {
       id: this.id,
       timestamp: this.timestamp.unix(),
       speaker: this.speaker,
-      text: this.text
-    }
+      text: this.text,
+    };
   }
 }
 
-module.exports = Line
+module.exports = Line;

--- a/scripts/models/pattern.js
+++ b/scripts/models/pattern.js
@@ -1,150 +1,154 @@
 // Parse and model regular expression and exact-match patterns.
 
 class Pattern {
-  canBeEndpoint () {
-    return true
+  canBeEndpoint() {
+    return true;
   }
 
-  matches (line) {
-    return false
+  matches(line) {
+    return false;
   }
 
-  matchesIn (cache) {
-    const match = cache.mostRecentMatch(this)
-    return match ? [match] : []
+  matchesIn(cache) {
+    const match = cache.mostRecentMatch(this);
+    return match ? [match] : [];
   }
 }
 
 class ExactPattern extends Pattern {
-  constructor (source) {
-    super()
-    this.source = source
+  constructor(source) {
+    super();
+    this.source = source;
   }
 
-  matches (line) {
-    return line.text.indexOf(this.source) !== -1
+  matches(line) {
+    return line.text.indexOf(this.source) !== -1;
   }
 
-  toString () {
-    return `"${this.source}"`
+  toString() {
+    return `"${this.source}"`;
   }
 }
 
 class RegexpPattern extends Pattern {
-  constructor (source) {
-    super()
-    this.rx = new RegExp(source)
+  constructor(source) {
+    super();
+    this.rx = new RegExp(source);
   }
 
-  matches (line) {
-    return this.rx.test(line.text)
+  matches(line) {
+    return this.rx.test(line.text);
   }
 
-  toString () {
-    return this.rx.toString()
+  toString() {
+    return this.rx.toString();
   }
 }
 
 class BetweenPattern extends Pattern {
-  endpoints (start, end) {
-    if (!start) throw new Error('Range without a start pattern')
-    if (!end) throw new Error('Range without an end pattern')
+  endpoints(start, end) {
+    if (!start) throw new Error("Range without a start pattern");
+    if (!end) throw new Error("Range without an end pattern");
 
-    if (!start.canBeEndpoint()) throw new Error(`${start} cannot be a range endpoint`)
-    if (!end.canBeEndpoint()) throw new Error(`${end} cannot be a range endpoint`)
+    if (!start.canBeEndpoint())
+      throw new Error(`${start} cannot be a range endpoint`);
+    if (!end.canBeEndpoint())
+      throw new Error(`${end} cannot be a range endpoint`);
 
-    this.start = start
-    this.end = end
+    this.start = start;
+    this.end = end;
   }
 
-  matchesIn (cache) {
-    return cache.between(this.start, this.end)
+  matchesIn(cache) {
+    return cache.between(this.start, this.end);
   }
 
-  canBeEndpoint () {
-    return false
+  canBeEndpoint() {
+    return false;
   }
 
-  toString () {
-    return `${this.start} ... ${this.end}`
+  toString() {
+    return `${this.start} ... ${this.end}`;
   }
 }
 
-function parse (source) {
-  const patterns = []
-  let patternSource = ''
-  let PatternConstructor = null
-  let patternDelimiter = null
+function parse(source) {
+  const patterns = [];
+  let patternSource = "";
+  let PatternConstructor = null;
+  let patternDelimiter = null;
 
-  let startPattern = null
-  let betweenPattern = null
+  let startPattern = null;
+  let betweenPattern = null;
 
-  let i = 0
+  let i = 0;
   while (i < source.length) {
-    let ch = source[i]
+    let ch = source[i];
 
     if (patternDelimiter !== null && PatternConstructor !== null) {
       // Within a pattern
-      if (ch === '\\') {
+      if (ch === "\\") {
         // Escape sequence. Unconditionally add the next character.
-        i++
-        patternSource += source[i]
+        i++;
+        patternSource += source[i];
       } else if (ch === patternDelimiter) {
         // Pattern delimiter. Instantiate the current pattern.
-        const pattern = new PatternConstructor(patternSource)
+        const pattern = new PatternConstructor(patternSource);
 
         if (betweenPattern) {
-          betweenPattern.endpoints(startPattern, pattern)
+          betweenPattern.endpoints(startPattern, pattern);
 
-          startPattern = null
-          betweenPattern = null
+          startPattern = null;
+          betweenPattern = null;
         } else {
-          patterns.push(pattern)
+          patterns.push(pattern);
         }
 
-        patternSource = ''
-        patternDelimiter = null
-        PatternConstructor = null
+        patternSource = "";
+        patternDelimiter = null;
+        PatternConstructor = null;
       } else {
-        patternSource += ch
+        patternSource += ch;
       }
     } else {
       if (ch === '"') {
-        PatternConstructor = ExactPattern
-        patternDelimiter = '"'
+        PatternConstructor = ExactPattern;
+        patternDelimiter = '"';
       } else if (ch === "'") {
-        PatternConstructor = ExactPattern
-        patternDelimiter = "'"
-      } else if (ch === '/') {
-        PatternConstructor = RegexpPattern
-        patternDelimiter = '/'
-      } else if (ch === '.') {
-        while (source[i + 1] === '.') {
-          i++
+        PatternConstructor = ExactPattern;
+        patternDelimiter = "'";
+      } else if (ch === "/") {
+        PatternConstructor = RegexpPattern;
+        patternDelimiter = "/";
+      } else if (ch === ".") {
+        while (source[i + 1] === ".") {
+          i++;
         }
 
-        startPattern = patterns.pop()
-        betweenPattern = new BetweenPattern()
-        patterns.push(betweenPattern)
+        startPattern = patterns.pop();
+        betweenPattern = new BetweenPattern();
+        patterns.push(betweenPattern);
       } else if (/\s/.test(ch)) {
         // Skip whitespace
       } else {
-        throw new Error('You need to quote patterns with \' or " for this command.')
+        throw new Error(
+          "You need to quote patterns with ' or \" for this command."
+        );
       }
     }
 
-    i++
+    i++;
   }
 
   if (patternDelimiter) {
-    throw new Error(`Unbalanced pattern delimiter: ${patternDelimiter}`)
+    throw new Error(`Unbalanced pattern delimiter: ${patternDelimiter}`);
   }
 
   if (betweenPattern) {
-    throw new Error('Range without an end pattern')
+    throw new Error("Range without an end pattern");
   }
 
-  return patterns
+  return patterns;
 }
 
-exports.parse = parse
+exports.parse = parse;

--- a/scripts/models/tally-map.js
+++ b/scripts/models/tally-map.js
@@ -1,75 +1,74 @@
-
 class TallyMap {
-  constructor (brain, key) {
-    this.brain = brain
-    this.key = key
+  constructor(brain, key) {
+    this.brain = brain;
+    this.key = key;
   }
 
-  forUser (uid) {
-    const userMap = this.brain.get(this.key) || {}
-    return userMap[uid] || {}
+  forUser(uid) {
+    const userMap = this.brain.get(this.key) || {};
+    return userMap[uid] || {};
   }
 
-  modifyTally (uid, key, delta) {
-    const userMap = this.brain.get(this.key) || {}
-    const userTally = userMap[uid] || {}
+  modifyTally(uid, key, delta) {
+    const userMap = this.brain.get(this.key) || {};
+    const userTally = userMap[uid] || {};
 
-    userTally[key] = (userTally[key] || 0) + delta
+    userTally[key] = (userTally[key] || 0) + delta;
     if (userTally[key] <= 0) {
-      delete userTally[key]
+      delete userTally[key];
     }
 
-    userMap[uid] = userTally
-    this.brain.set(this.key, userMap)
+    userMap[uid] = userTally;
+    this.brain.set(this.key, userMap);
   }
 
-  topForUser (uid, n, callback) {
-    const userMap = this.forUser(uid)
+  topForUser(uid, n, callback) {
+    const userMap = this.forUser(uid);
 
-    const pairs = []
+    const pairs = [];
     for (const k in userMap) {
-      pairs.push([k, userMap[k]])
+      pairs.push([k, userMap[k]]);
     }
-    pairs.sort((a, b) => b[1] - a[1])
+    pairs.sort((a, b) => b[1] - a[1]);
 
-    let count = 0
+    let count = 0;
     for (const pair of pairs) {
       if (count >= n) {
-        return
+        return;
       }
 
-      callback(null, ...pair)
-      count++
+      callback(null, ...pair);
+      count++;
     }
   }
 
-  topForKey (key, n, callback) {
-    const userMap = this.brain.get(this.key) || {}
-    const perUserPairs = []
+  topForKey(key, n, callback) {
+    const userMap = this.brain.get(this.key) || {};
+    const perUserPairs = [];
     for (const uid in userMap) {
-      const tally = userMap[uid][key] || 0
-      perUserPairs.push([uid, tally])
+      const tally = userMap[uid][key] || 0;
+      perUserPairs.push([uid, tally]);
     }
-    perUserPairs.sort((a, b) => b[1] - a[1])
+    perUserPairs.sort((a, b) => b[1] - a[1]);
 
-    let count = 0
+    let count = 0;
     for (const pair of perUserPairs) {
       if (count >= n) {
-        return
+        return;
       }
 
-      callback(null, ...pair)
-      count++
+      callback(null, ...pair);
+      count++;
     }
   }
 
-  static reactionsReceived (robot) {
-    return new TallyMap(robot.brain, 'reactionsReceived')
+  static reactionsReceived(robot) {
+    return new TallyMap(robot.brain, "reactionsReceived");
   }
 
-  static reactionsGiven (robot) {
-    return new TallyMap(robot.brain, 'reactionsGiven')
+  static reactionsGiven(robot) {
+    return new TallyMap(robot.brain, "reactionsGiven");
   }
 }
 
-module.exports = { TallyMap }
+module.exports = {TallyMap};

--- a/scripts/roles/index.js
+++ b/scripts/roles/index.js
@@ -1,54 +1,58 @@
 // Specific roles that Do Something.
 
 class Role {
-  constructor (name) {
-    this.name = name
+  constructor(name) {
+    this.name = name;
   }
 
-  isAllowed (robot, user) {
-    return robot.auth.hasRole(user, this.name)
+  isAllowed(robot, user) {
+    return robot.auth.hasRole(user, this.name);
   }
 
-  verify (robot, msg) {
+  verify(robot, msg) {
     if (!this.isAllowed(robot, msg.message.user)) {
-      msg.reply([
-        `You can't do that! You're not a *${this.name}*.`,
-        `Ask an admin to run \`${robot.name} grant ${msg.message.user.name} the ${this.name} role\`.`
-      ].join('\n'))
-      return false
+      msg.reply(
+        [
+          `You can't do that! You're not a *${this.name}*.`,
+          `Ask an admin to run \`${robot.name} grant ${
+            msg.message.user.name
+          } the ${this.name} role\`.`,
+        ].join("\n")
+      );
+      return false;
     }
 
-    return true
+    return true;
   }
 }
 
 exports.Anyone = {
   isAllowed: () => true,
-  verify: () => true
-}
+  verify: () => true,
+};
 
 exports.Admin = {
-  isAllowed (robot, user) {
-    return robot.auth.isAdmin(user)
+  isAllowed(robot, user) {
+    return robot.auth.isAdmin(user);
   },
 
-  verify (robot, msg) {
+  verify(robot, msg) {
     if (!robot.auth.isAdmin(msg.message.user)) {
-      msg.reply('Only an admin can do that.')
-      return false
+      msg.reply("Only an admin can do that.");
+      return false;
     }
-    return true
-  }
-}
+    return true;
+  },
+};
 
-exports.QuotePontiff = new Role('quote pontiff')
+exports.QuotePontiff = new Role("quote pontiff");
 
-exports.PoetLaureate = new Role('poet laureate')
+exports.PoetLaureate = new Role("poet laureate");
 
-exports.MapMaker = new Role('mapmaker')
+exports.MapMaker = new Role("mapmaker");
 
-exports.withName = function (name, def = exports.Anyone) {
-  if (!name) return def
-  if (/^anyone$/i.test(name)) return exports.Anyone
-  return new Role(name)
-}
+exports.withName = function(name, def = exports.Anyone) {
+  if (!name) return def;
+  if (/^anyone$/i.test(name)) return exports.Anyone;
+  return new Role(name);
+};

--- a/test/api/brain.test.js
+++ b/test/api/brain.test.js
@@ -1,158 +1,193 @@
-const util = require('util')
+const util = require("util");
 
-const { BrainResolver, BrainMutator } = require('../../scripts/api/brain')
+const {BrainResolver, BrainMutator} = require("../../scripts/api/brain");
 
-describe('BrainResolver', function () {
-  let bot, brain, req, resolver
-  let authorized, unauthorized
+describe("BrainResolver", function() {
+  let bot, brain, req, resolver;
+  let authorized, unauthorized;
 
-  beforeEach(async function () {
-    bot = new BotContext()
-    await bot.loadAuth('1')
+  beforeEach(async function() {
+    bot = new BotContext();
+    await bot.loadAuth("1");
 
-    authorized = bot.createUser('1', 'authorized')
-    unauthorized = bot.createUser('2', 'denied')
+    authorized = bot.createUser("1", "authorized");
+    unauthorized = bot.createUser("2", "denied");
 
-    brain = bot.getRobot().brain
+    brain = bot.getRobot().brain;
 
-    req = { robot: bot.getRobot(), user: authorized }
-    resolver = new BrainResolver()
-  })
+    req = {robot: bot.getRobot(), user: authorized};
+    resolver = new BrainResolver();
+  });
 
-  afterEach(function () {
-    bot.destroy()
-  })
+  afterEach(function() {
+    bot.destroy();
+  });
 
-  describe('keys', function () {
-    let allKeys
+  describe("keys", function() {
+    let allKeys;
 
-    beforeEach(function () {
-      allKeys = []
+    beforeEach(function() {
+      allKeys = [];
       for (let i = 0; i < 10; i++) {
-        const prefix = i % 2 === 0 ? 'even' : 'odd'
-        const key = `${prefix}-key:${i}`
-        allKeys.push(key)
-        brain.set(key, `value ${i}`)
+        const prefix = i % 2 === 0 ? "even" : "odd";
+        const key = `${prefix}-key:${i}`;
+        allKeys.push(key);
+        brain.set(key, `value ${i}`);
       }
-    })
+    });
 
-    it('only permits admin access', function () {
+    it("only permits admin access", function() {
       expect(() => {
-        resolver.keys({}, { robot: bot.getRobot(), user: unauthorized })
-      }).to.throw(/must be an admin/)
-    })
+        resolver.keys({}, {robot: bot.getRobot(), user: unauthorized});
+      }).to.throw(/must be an admin/);
+    });
 
-    it('lists known keys', function () {
-      expect(resolver.keys({ limit: Infinity, prefix: '' }, req)).to.have.members(allKeys)
-    })
+    it("lists known keys", function() {
+      expect(resolver.keys({limit: Infinity, prefix: ""}, req)).to.have.members(
+        allKeys
+      );
+    });
 
-    it('limits to the first N results', function () {
-      expect(resolver.keys({ limit: 5, prefix: '' }, req)).to.have.length(5)
-    })
+    it("limits to the first N results", function() {
+      expect(resolver.keys({limit: 5, prefix: ""}, req)).to.have.length(5);
+    });
 
-    it('limits by a prefix', function () {
-      expect(resolver.keys({ limit: Infinity, prefix: 'even' }, req)).to.have.members([
-        'even-key:0', 'even-key:2', 'even-key:4', 'even-key:6', 'even-key:8'
-      ])
-    })
-  })
+    it("limits by a prefix", function() {
+      expect(
+        resolver.keys({limit: Infinity, prefix: "even"}, req)
+      ).to.have.members([
+        "even-key:0",
+        "even-key:2",
+        "even-key:4",
+        "even-key:6",
+        "even-key:8",
+      ]);
+    });
+  });
 
-  describe('key', function () {
-    let root
+  describe("key", function() {
+    let root;
 
-    beforeEach(function () {
+    beforeEach(function() {
       root = {
         key0: {
-          key00: 'astring',
+          key00: "astring",
           key01: 100,
-          key02: null
+          key02: null,
         },
-        key1: 'other'
-      }
-      brain.set('the-key', root)
-    })
+        key1: "other",
+      };
+      brain.set("the-key", root);
+    });
 
-    it('only permits admin access', function () {
+    it("only permits admin access", function() {
       expect(() => {
-        resolver.key({ name: 'the-key', property: [] }, { robot: bot.getRobot(), user: unauthorized })
-      }).to.throw(/must be an admin/)
-    })
+        resolver.key(
+          {name: "the-key", property: []},
+          {robot: bot.getRobot(), user: unauthorized}
+        );
+      }).to.throw(/must be an admin/);
+    });
 
-    it('throws an error if the key is unknown', function () {
-      expect(() => resolver.key({ name: 'bad-key', property: [] }, req)).to.throw(/Unknown brain key/)
-    })
+    it("throws an error if the key is unknown", function() {
+      expect(() => resolver.key({name: "bad-key", property: []}, req)).to.throw(
+        /Unknown brain key/
+      );
+    });
 
-    it('accesses the root-level object of a key as JSON', function () {
-      const json = resolver.key({ name: 'the-key', property: [] }, req).json({ pretty: false }, req)
-      expect(JSON.parse(json)).to.deep.equal(root)
-    })
+    it("accesses the root-level object of a key as JSON", function() {
+      const json = resolver
+        .key({name: "the-key", property: []}, req)
+        .json({pretty: false}, req);
+      expect(JSON.parse(json)).to.deep.equal(root);
+    });
 
-    it('inspects the root-level object of a key with a given depth', function () {
-      const insp = resolver.key({ name: 'the-key', property: [] }, req).inspect({ depth: 2 }, req)
-      expect(insp).to.equal(util.inspect(root, { breakLength: 100 }))
-    })
+    it("inspects the root-level object of a key with a given depth", function() {
+      const insp = resolver
+        .key({name: "the-key", property: []}, req)
+        .inspect({depth: 2}, req);
+      expect(insp).to.equal(util.inspect(root, {breakLength: 100}));
+    });
 
-    it('enumerates child properties of an object', function () {
-      const props = resolver.key({ name: 'the-key', property: [] }, req)
-        .children({ limit: 4, prefix: '' }, req)
-      expect(props).to.have.members(['key0', 'key1'])
-    })
+    it("enumerates child properties of an object", function() {
+      const props = resolver
+        .key({name: "the-key", property: []}, req)
+        .children({limit: 4, prefix: ""}, req);
+      expect(props).to.have.members(["key0", "key1"]);
+    });
 
-    it('filters and limits the child properties of an object', function () {
-      root.key0['asdf00'] = 'no'
-      root.key0['asdf01'] = 'no'
-      root.key0['asdf02'] = 'no'
+    it("filters and limits the child properties of an object", function() {
+      root.key0["asdf00"] = "no";
+      root.key0["asdf01"] = "no";
+      root.key0["asdf02"] = "no";
 
-      const props = resolver.key({ name: 'the-key', property: ['key0'] }, req)
-        .children({ limit: 2, prefix: 'key' }, req)
-      expect(props).to.have.members(['key00', 'key01'])
-    })
+      const props = resolver
+        .key({name: "the-key", property: ["key0"]}, req)
+        .children({limit: 2, prefix: "key"}, req);
+      expect(props).to.have.members(["key00", "key01"]);
+    });
 
-    it('accesses a deep property of an object as JSON', function () {
-      const child = resolver.key({ name: 'the-key', property: ['key0'] }, req).json({ pretty: false }, req)
-      expect(JSON.parse(child)).to.deep.equal({ key00: 'astring', key01: 100, key02: null })
-    })
+    it("accesses a deep property of an object as JSON", function() {
+      const child = resolver
+        .key({name: "the-key", property: ["key0"]}, req)
+        .json({pretty: false}, req);
+      expect(JSON.parse(child)).to.deep.equal({
+        key00: "astring",
+        key01: 100,
+        key02: null,
+      });
+    });
 
-    it('inspects a deep property of an object', function () {
-      const child = resolver.key({ name: 'the-key', property: ['key0', 'key00'] }, req).inspect({ depth: 1 }, req)
-      expect(child).to.equal("'astring'")
-    })
+    it("inspects a deep property of an object", function() {
+      const child = resolver
+        .key({name: "the-key", property: ["key0", "key00"]}, req)
+        .inspect({depth: 1}, req);
+      expect(child).to.equal("'astring'");
+    });
 
-    it('throws an error if a property in the chain is invalid', function () {
-      expect(() => resolver.key({ name: 'the-key', property: ['key0', 'no', 'yes'] }, req)).to.throw(/Invalid property/)
-    })
-  })
-})
+    it("throws an error if a property in the chain is invalid", function() {
+      expect(() =>
+        resolver.key({name: "the-key", property: ["key0", "no", "yes"]}, req)
+      ).to.throw(/Invalid property/);
+    });
+  });
+});
 
-describe('BrainMutator', function () {
-  let bot, authorized, unauthorized, req, brain
+describe("BrainMutator", function() {
+  let bot, authorized, unauthorized, req, brain;
 
-  beforeEach(async function () {
-    bot = new BotContext()
-    await bot.loadAuth('1')
+  beforeEach(async function() {
+    bot = new BotContext();
+    await bot.loadAuth("1");
 
-    authorized = bot.createUser('1', 'authorized')
-    unauthorized = bot.createUser('2', 'denied')
+    authorized = bot.createUser("1", "authorized");
+    unauthorized = bot.createUser("2", "denied");
 
-    brain = bot.getRobot().brain
+    brain = bot.getRobot().brain;
 
-    req = { robot: bot.getRobot(), user: authorized }
-  })
+    req = {robot: bot.getRobot(), user: authorized};
+  });
 
-  it('only permits root access', function () {
+  it("only permits root access", function() {
     expect(() => {
-      BrainMutator.set({}, { robot: bot.getRobot(), user: unauthorized })
-    }).to.throw(/must be an admin/)
-  })
+      BrainMutator.set({}, {robot: bot.getRobot(), user: unauthorized});
+    }).to.throw(/must be an admin/);
+  });
 
-  it('sets a root key', function () {
-    BrainMutator.set({ name: 'some:key', property: [], value: '{"foo": 100}' }, req)
-    expect(brain.get('some:key')).to.deep.equal({ foo: 100 })
-  })
+  it("sets a root key", function() {
+    BrainMutator.set(
+      {name: "some:key", property: [], value: '{"foo": 100}'},
+      req
+    );
+    expect(brain.get("some:key")).to.deep.equal({foo: 100});
+  });
 
-  it('sets a deeper key', function () {
-    brain.set('deep:key', { one: { two: { three: 10 } } })
-    BrainMutator.set({ name: 'deep:key', property: ['one', 'two', 'three'], value: '"abc"' }, req)
-    expect(brain.get('deep:key')).to.deep.equal({ one: { two: { three: 'abc' } } })
-  })
-})
+  it("sets a deeper key", function() {
+    brain.set("deep:key", {one: {two: {three: 10}}});
+    BrainMutator.set(
+      {name: "deep:key", property: ["one", "two", "three"], value: '"abc"'},
+      req
+    );
+    expect(brain.get("deep:key")).to.deep.equal({one: {two: {three: "abc"}}});
+  });
+});

--- a/test/api/cache.test.js
+++ b/test/api/cache.test.js
@@ -1,101 +1,102 @@
-const Helper = require('hubot-test-helper')
-const helper = new Helper([])
+const Helper = require("hubot-test-helper");
+const helper = new Helper([]);
 
-const { CacheResolver } = require('../../scripts/api/cache')
-const cache = require('../../scripts/models/cache')
+const {CacheResolver} = require("../../scripts/api/cache");
+const cache = require("../../scripts/models/cache");
 
-describe('CacheResolver', function () {
-  let room, user, req, resolver
+describe("CacheResolver", function() {
+  let room, user, req, resolver;
 
-  beforeEach(function () {
-    cache.clear()
+  beforeEach(function() {
+    cache.clear();
 
-    room = helper.createRoom({ httpd: false })
+    room = helper.createRoom({httpd: false});
 
-    const robot = room.robot
-    user = robot.brain.userForId('1', { name: 'self' })
-    robot.brain.userForId('2', { name: 'aaa' })
-    robot.brain.userForId('3', { name: 'bbb' })
-    robot.brain.userForId('4', { name: 'ccc' })
+    const robot = room.robot;
+    user = robot.brain.userForId("1", {name: "self"});
+    robot.brain.userForId("2", {name: "aaa"});
+    robot.brain.userForId("3", {name: "bbb"});
+    robot.brain.userForId("4", {name: "ccc"});
 
-    req = { robot, user }
-    resolver = new CacheResolver()
-  })
+    req = {robot, user};
+    resolver = new CacheResolver();
+  });
 
-  afterEach(function () {
-    room.destroy()
-  })
+  afterEach(function() {
+    room.destroy();
+  });
 
-  describe('knownChannels', function () {
-    it('returns an empty array if no caches are present', function () {
-      expect(resolver.knownChannels({}, req)).to.eql([])
-    })
+  describe("knownChannels", function() {
+    it("returns an empty array if no caches are present", function() {
+      expect(resolver.knownChannels({}, req)).to.eql([]);
+    });
 
-    it('returns the populated caches', function () {
-      cache.forChannel(req.robot, 'general')
-      cache.forChannel(req.robot, 'pushbotdev')
+    it("returns the populated caches", function() {
+      cache.forChannel(req.robot, "general");
+      cache.forChannel(req.robot, "pushbotdev");
 
       expect(resolver.knownChannels({}, req)).to.have.members([
-        'general',
-        'pushbotdev'
-      ])
-    })
+        "general",
+        "pushbotdev",
+      ]);
+    });
 
-    it('translates channel IDs to channel names when available', function () {
-      cache.forChannel(req.robot, 'C100')
-      cache.forChannel(req.robot, 'C200')
+    it("translates channel IDs to channel names when available", function() {
+      cache.forChannel(req.robot, "C100");
+      cache.forChannel(req.robot, "C200");
 
       req.robot.adapter.client = {
         rtm: {
           dataStore: {
-            getChannelGroupOrDMById (id) {
-              if (id === 'C100') return { name: 'general' }
-              return undefined
-            }
-          }
-        }
-      }
+            getChannelGroupOrDMById(id) {
+              if (id === "C100") return {name: "general"};
+              return undefined;
+            },
+          },
+        },
+      };
 
       expect(resolver.knownChannels({}, req)).to.have.members([
-        'general',
-        'C200'
-      ])
-    })
-  })
+        "general",
+        "C200",
+      ]);
+    });
+  });
 
-  describe('linesForChannel', function () {
-    it('returns an array of cached lines', function () {
-      cache.forChannel(req.robot, '#general')
-        .append(message('aaa', 'line one'))
-        .append(message('bbb', 'line two\nline three'))
-        .append(message('ccc', 'line four'))
+  describe("linesForChannel", function() {
+    it("returns an array of cached lines", function() {
+      cache
+        .forChannel(req.robot, "#general")
+        .append(message("aaa", "line one"))
+        .append(message("bbb", "line two\nline three"))
+        .append(message("ccc", "line four"));
 
-      const lines = resolver.linesForChannel({ channel: '#general' }, req)
-      expect(lines).to.have.length(4)
+      const lines = resolver.linesForChannel({channel: "#general"}, req);
+      expect(lines).to.have.length(4);
 
-      expect(lines[0].speaker.name).to.equal('aaa')
-      expect(lines[0].text).to.equal('line one')
+      expect(lines[0].speaker.name).to.equal("aaa");
+      expect(lines[0].text).to.equal("line one");
 
-      expect(lines[1].speaker.name).to.equal('bbb')
-      expect(lines[1].text).to.equal('line two')
+      expect(lines[1].speaker.name).to.equal("bbb");
+      expect(lines[1].text).to.equal("line two");
 
-      expect(lines[2].speaker.name).to.equal('bbb')
-      expect(lines[2].text).to.equal('line three')
+      expect(lines[2].speaker.name).to.equal("bbb");
+      expect(lines[2].text).to.equal("line three");
 
-      expect(lines[3].speaker.name).to.equal('ccc')
-      expect(lines[3].text).to.equal('line four')
-    })
+      expect(lines[3].speaker.name).to.equal("ccc");
+      expect(lines[3].text).to.equal("line four");
+    });
 
-    it('returns an empty array for an empty cache', function () {
-      cache.forChannel(req.robot, '#general')
+    it("returns an empty array for an empty cache", function() {
+      cache.forChannel(req.robot, "#general");
 
-      const lines = resolver.linesForChannel({ channel: '#general' }, req)
-      expect(lines).to.eql([])
-    })
+      const lines = resolver.linesForChannel({channel: "#general"}, req);
+      expect(lines).to.eql([]);
+    });
 
-    it('returns null for an unknown channel', function () {
-      const lines = resolver.linesForChannel({ channel: '#nope' }, req)
-      expect(lines).to.be.null
-    })
-  })
-})
+    it("returns null for an unknown channel", function() {
+      const lines = resolver.linesForChannel({channel: "#nope"}, req);
+      expect(lines).to.be.null;
+    });
+  });
+});

--- a/test/api/document-set.test.js
+++ b/test/api/document-set.test.js
@@ -1,381 +1,448 @@
-const { createDocumentSet } = require('../../scripts/documentset')
-const { DocumentSetResolver } = require('../../scripts/api/document-set')
+const {createDocumentSet} = require("../../scripts/documentset");
+const {DocumentSetResolver} = require("../../scripts/api/document-set");
 
-describe('DocumentSetResolver', function () {
-  let set, resolver
+describe("DocumentSetResolver", function() {
+  let set, resolver;
 
-  beforeEach(function () {
-    usesDatabase(this)
+  beforeEach(function() {
+    usesDatabase(this);
 
     const robot = {
-      postgres: database
-    }
+      postgres: database,
+    };
 
-    set = createDocumentSet(robot, 'blork', {})
-    resolver = new DocumentSetResolver('blork', set)
-  })
+    set = createDocumentSet(robot, "blork", {});
+    resolver = new DocumentSetResolver("blork", set);
+  });
 
-  afterEach(async function () {
-    await set.destroy()
-  })
+  afterEach(async function() {
+    await set.destroy();
+  });
 
-  async function populate (...specs) {
-    const promises = []
+  async function populate(...specs) {
+    const promises = [];
     for (let i = 0; i < specs.length; i++) {
-      const spec = specs[i]
-      const body = spec.body || `entry #${i}`
-      const attrs = []
+      const spec = specs[i];
+      const body = spec.body || `entry #${i}`;
+      const attrs = [];
       if (spec.subject) {
-        attrs.push({ kind: 'subject', value: spec.subject })
+        attrs.push({kind: "subject", value: spec.subject});
       }
       if (spec.speakers) {
-        attrs.push(...spec.speakers.map(speaker => {
-          return { kind: 'speaker', value: speaker }
-        }))
+        attrs.push(
+          ...spec.speakers.map(speaker => {
+            return {kind: "speaker", value: speaker};
+          })
+        );
       }
       if (spec.mentions) {
-        attrs.push(...spec.mentions.map(mention => {
-          return { kind: 'mention', value: mention }
-        }))
+        attrs.push(
+          ...spec.mentions.map(mention => {
+            return {kind: "mention", value: mention};
+          })
+        );
       }
 
-      promises.push(set.add('spec', body, attrs))
+      promises.push(set.add("spec", body, attrs));
     }
-    await Promise.all(promises)
+    await Promise.all(promises);
   }
 
-  describe('random', function () {
-    it('with no documents', async function () {
-      const result = await resolver.random({ criteria: {} })
-      expect(result.found).to.equal(false)
-    })
+  describe("random", function() {
+    it("with no documents", async function() {
+      const result = await resolver.random({criteria: {}});
+      expect(result.found).to.equal(false);
+    });
 
-    it('with empty criteria', async function () {
-      await populate({ body: 'one' })
+    it("with empty criteria", async function() {
+      await populate({body: "one"});
 
-      const result = await resolver.random({ criteria: {} })
-      expect(result.found).to.equal(true)
-    })
+      const result = await resolver.random({criteria: {}});
+      expect(result.found).to.equal(true);
+    });
 
-    it('matching a query', async function () {
+    it("matching a query", async function() {
       await populate(
-        {}, {}, {}, {}, {},
-        { body: 'one aaa one' },
-        {}, {}, {}, {}, {}
-      )
-
-      const result = await resolver.random({ criteria: { query: 'aaa' } })
-      expect(result.found).to.equal(true)
-      expect(result.text).to.equal('one aaa one')
-    })
-
-    it('with a matching subject', async function () {
-      await populate(
-        {}, {}, {}, {}, {},
-        { body: 'this one', subject: 'me' },
-        { subject: 'other' }, { subject: 'other' },
-        {}, {}, {}, {}, {}
-      )
-
-      const result = await resolver.random({ criteria: { subject: 'me' } })
-      expect(result.found).to.equal(true)
-      expect(result.text).to.equal('this one')
-    })
-
-    it('with all speakers', async function () {
-      await populate(
-        {}, {}, {}, {}, {},
-        { body: 'this one', speakers: ['yes0', 'yes1'] },
-        { body: 'only one', speakers: ['yes1'] },
-        { body: 'different', speakers: ['no0'] },
-        {}, {}, {}, {}, {}
-      )
-
-      const result = await resolver.random({ criteria: { speakers: ['yes0', 'yes1'] } })
-      expect(result.found).to.equal(true)
-      expect(result.text).to.equal('this one')
-    })
-
-    it('with all mentions', async function () {
-      await populate(
-        {}, {}, {}, {}, {},
-        { body: 'this one', mentions: ['yes0', 'yes1'] },
-        { body: 'only one', mentions: ['yes1'] },
-        { body: 'different', mentions: ['no0'] },
-        {}, {}, {}, {}, {}
-      )
-
-      const result = await resolver.random({ criteria: { mentions: ['yes0', 'yes1'] } })
-      expect(result.found).to.equal(true)
-      expect(result.text).to.equal('this one')
-    })
-  })
-
-  describe('all', function () {
-    it('with no documents', async function () {
-      const result = await resolver.all({ criteria: {} })
-
-      expect(result.edges).to.have.lengthOf(0)
-      expect(result.pageInfo.hasPreviousPage).to.equal(false)
-      expect(result.pageInfo.hasNextPage).to.equal(false)
-    })
-
-    it('with "first" less than the document count', async function () {
-      await populate({}, {}, {}, {}, {})
-
-      const result = await resolver.all({ criteria: {}, first: 4 })
-      expect(result.edges).to.have.lengthOf(4)
-      expect(result.pageInfo.hasPreviousPage).to.equal(false)
-      expect(result.pageInfo.hasNextPage).to.equal(true)
-    })
-
-    it('with "first" equal to the document count', async function () {
-      await populate({}, {}, {}, {}, {})
-
-      const result = await resolver.all({ criteria: {}, first: 5 })
-      expect(result.edges).to.have.lengthOf(5)
-      expect(result.pageInfo.hasPreviousPage).to.equal(false)
-      expect(result.pageInfo.hasNextPage).to.equal(false)
-    })
-
-    it('with "first" greater than the document count', async function () {
-      await populate({}, {}, {}, {}, {})
-
-      const result = await resolver.all({ criteria: {}, first: 10 })
-      expect(result.edges).to.have.lengthOf(5)
-      expect(result.pageInfo.hasPreviousPage).to.equal(false)
-      expect(result.pageInfo.hasNextPage).to.equal(false)
-    })
-
-    it('with "after" less than the first document ID', async function () {
-      await populate({}, {}, {}, {}, {})
-
-      const result = await resolver.all({ criteria: {}, after: '0' })
-      expect(result.edges).to.have.lengthOf(5)
-      expect(result.pageInfo.hasPreviousPage).to.equal(false)
-      expect(result.pageInfo.hasNextPage).to.equal(false)
-    })
-
-    it('with "after" as an intermediate document ID', async function () {
-      await populate({}, {}, {}, {}, {})
-
-      const result = await resolver.all({ criteria: {}, after: '3' })
-      expect(result.edges).to.have.lengthOf(2)
-      expect(result.pageInfo.hasPreviousPage).to.equal(true)
-      expect(result.pageInfo.hasNextPage).to.equal(false)
-    })
-
-    it('with "after" greater than the last document ID', async function () {
-      await populate({}, {}, {}, {}, {})
-
-      const result = await resolver.all({ criteria: {}, after: '10' })
-      expect(result.edges).to.have.lengthOf(0)
-      expect(result.pageInfo.hasPreviousPage).to.equal(true)
-      expect(result.pageInfo.hasNextPage).to.equal(false)
-    })
-
-    it('matching a query', async function () {
-      await populate(
-        {}, {},
-        { body: 'aaa 0' }, { body: 'aaa 1' }, { body: '2 aaa' },
-        {}, {}
-      )
-
-      const result = await resolver.all({ criteria: { query: 'aaa' } })
-      expect(result.edges).to.have.lengthOf(3)
-      expect(result.edges.map(edge => edge.node.text)).to.have.members([
-        'aaa 0', 'aaa 1', '2 aaa'
-      ])
-      expect(result.pageInfo.hasPreviousPage).to.equal(false)
-      expect(result.pageInfo.hasNextPage).to.equal(false)
-    })
-
-    it('with a matching subject', async function () {
-      await populate(
-        {}, {},
-        { body: 'yes 0', subject: 'me' }, { body: 'yes 1', subject: 'me' },
-        { body: 'no 0', subject: 'other' },
-        {}, {}
-      )
-
-      const result = await resolver.all({ criteria: { subject: 'me' } })
-      expect(result.edges).to.have.lengthOf(2)
-      expect(result.edges.map(edge => edge.node.text)).to.have.members([
-        'yes 0', 'yes 1'
-      ])
-      expect(result.pageInfo.hasPreviousPage).to.equal(false)
-      expect(result.pageInfo.hasNextPage).to.equal(false)
-    })
-
-    it('with all speakers', async function () {
-      await populate(
-        {}, {},
-        { body: 'yes 0', speakers: ['me0', 'me1'] },
-        { body: 'yes 1', speakers: ['me0', 'me1'] },
-        { body: 'no 0', speakers: ['me1'] },
-        { body: 'no 1', speakers: ['me1', 'other'] },
-        { body: 'no 2', speakers: ['other'] },
-        {}, {}
-      )
-
-      const result = await resolver.all({ criteria: { speakers: ['me0', 'me1'] } })
-      expect(result.edges).to.have.lengthOf(2)
-      expect(result.edges.map(edge => edge.node.text)).to.have.members([
-        'yes 0', 'yes 1'
-      ])
-      expect(result.pageInfo.hasPreviousPage).to.equal(false)
-      expect(result.pageInfo.hasNextPage).to.equal(false)
-    })
-
-    it('with all mentions', async function () {
-      await populate(
-        {}, {},
-        { body: 'yes 0', mentions: ['me0', 'me1'] },
-        { body: 'yes 1', mentions: ['me1', 'me0'] },
-        { body: 'no 0', mentions: ['me1'] },
-        { body: 'no 1', mentions: ['me1', 'other'] },
-        { body: 'no 2', mentions: ['other'] },
-        {}, {}
-      )
-
-      const result = await resolver.all({ criteria: { mentions: ['me0', 'me1'] } })
-      expect(result.edges).to.have.lengthOf(2)
-      expect(result.edges.map(edge => edge.node.text)).to.have.members([
-        'yes 0', 'yes 1'
-      ])
-      expect(result.pageInfo.hasPreviousPage).to.equal(false)
-      expect(result.pageInfo.hasNextPage).to.equal(false)
-    })
-  })
-
-  describe('mine', function () {
-    it('with no documents', async function () {
-      const req = { user: { name: 'me' } }
-      const result = await resolver.mine({}, req)
-
-      expect(result.found).to.equal(false)
-    })
-
-    it('with no documents matching the subject of the current user', async function () {
-      await populate(
-        {}, {}, {}, {},
-        { subject: 'other' }
-      )
-
-      const req = { user: { name: 'me' } }
-      const result = await resolver.mine({}, req)
-
-      expect(result.found).to.equal(false)
-    })
-
-    it('with a document matching the subject of the current user', async function () {
-      await populate(
-        {}, {}, {}, {},
-        { body: 'yes', subject: 'me' },
-        { subject: 'other' }
-      )
-
-      const req = { user: { name: 'me' } }
-      const result = await resolver.mine({}, req)
-
-      expect(result.found).to.equal(true)
-      expect(result.text).to.equal('yes')
-    })
-  })
-
-  describe('rank', function () {
-    it('with no documents', async function () {
-      const result = await resolver.rank({ speaker: 'me' })
-      expect(result).to.equal(0)
-    })
-
-    it('with no documents matching with a matching speaker', async function () {
-      await populate(
-        {}, {}, { speakers: ['other'] }, { speakers: ['no'] }
-      )
-
-      const result = await resolver.rank({ speaker: 'me' })
-      expect(result).to.equal(0)
-    })
-
-    it('with documents matching the requested speaker', async function () {
-      await populate(
-        { speakers: ['me'] },
-        { speakers: ['me'] },
-        { speakers: ['me'] },
-        { speakers: ['first'] },
-        { speakers: ['first'] },
-        { speakers: ['first'] },
-        { speakers: ['first'] },
-        { speakers: ['last'] },
-        { speakers: ['last'] }
-      )
-
-      const result = await resolver.rank({ speaker: 'me' })
-      expect(result).to.equal(2)
-    })
-  })
-
-  describe('count', function () {
-    it('with no documents', async function () {
-      const result = await resolver.count({ criteria: {} })
-      expect(result).to.equal(0)
-    })
-
-    it('with an empty query', async function () {
-      await populate({}, {}, {})
-
-      const result = await resolver.count({ criteria: {} })
-      expect(result).to.equal(3)
-    })
-
-    it('matching a query', async function () {
-      await populate(
-        {}, {}, {},
-        { body: 'yes zzz 0' }, { body: 'yes 1 zzz' },
-        {}, {}
-      )
-
-      const result = await resolver.count({ criteria: { query: 'zzz' } })
-      expect(result).to.equal(2)
-    })
-
-    it('with a matching subject', async function () {
-      await populate(
-        {}, {}, {},
-        { subject: 'me' }, { subject: 'me' },
-        { subject: 'other' },
-        {}, {}
-      )
-
-      const result = await resolver.count({ criteria: { subject: 'me' } })
-      expect(result).to.equal(2)
-    })
-
-    it('with all speakers', async function () {
-      await populate(
-        { speakers: ['yes0'] },
-        { speakers: ['yes0', 'yes1'] },
-        { speakers: ['yes0', 'yes1', 'extra'] },
-        { speakers: ['no0'] },
+        {},
+        {},
+        {},
+        {},
+        {},
+        {body: "one aaa one"},
+        {},
+        {},
+        {},
+        {},
         {}
-      )
+      );
 
-      const result = await resolver.count({ criteria: { speakers: ['yes0', 'yes1'] } })
-      expect(result).to.equal(2)
-    })
+      const result = await resolver.random({criteria: {query: "aaa"}});
+      expect(result.found).to.equal(true);
+      expect(result.text).to.equal("one aaa one");
+    });
 
-    it('with all mentions', async function () {
+    it("with a matching subject", async function() {
       await populate(
-        { mentions: ['yes0'] },
-        { mentions: ['yes0', 'yes1'] },
-        { mentions: ['yes0', 'yes1', 'extra'] },
-        { mentions: ['no0'] },
+        {},
+        {},
+        {},
+        {},
+        {},
+        {body: "this one", subject: "me"},
+        {subject: "other"},
+        {subject: "other"},
+        {},
+        {},
+        {},
+        {},
         {}
-      )
+      );
 
-      const result = await resolver.count({ criteria: { mentions: ['yes0', 'yes1'] } })
-      expect(result).to.equal(2)
-    })
-  })
-})
+      const result = await resolver.random({criteria: {subject: "me"}});
+      expect(result.found).to.equal(true);
+      expect(result.text).to.equal("this one");
+    });
+
+    it("with all speakers", async function() {
+      await populate(
+        {},
+        {},
+        {},
+        {},
+        {},
+        {body: "this one", speakers: ["yes0", "yes1"]},
+        {body: "only one", speakers: ["yes1"]},
+        {body: "different", speakers: ["no0"]},
+        {},
+        {},
+        {},
+        {},
+        {}
+      );
+
+      const result = await resolver.random({
+        criteria: {speakers: ["yes0", "yes1"]},
+      });
+      expect(result.found).to.equal(true);
+      expect(result.text).to.equal("this one");
+    });
+
+    it("with all mentions", async function() {
+      await populate(
+        {},
+        {},
+        {},
+        {},
+        {},
+        {body: "this one", mentions: ["yes0", "yes1"]},
+        {body: "only one", mentions: ["yes1"]},
+        {body: "different", mentions: ["no0"]},
+        {},
+        {},
+        {},
+        {},
+        {}
+      );
+
+      const result = await resolver.random({
+        criteria: {mentions: ["yes0", "yes1"]},
+      });
+      expect(result.found).to.equal(true);
+      expect(result.text).to.equal("this one");
+    });
+  });
+
+  describe("all", function() {
+    it("with no documents", async function() {
+      const result = await resolver.all({criteria: {}});
+
+      expect(result.edges).to.have.lengthOf(0);
+      expect(result.pageInfo.hasPreviousPage).to.equal(false);
+      expect(result.pageInfo.hasNextPage).to.equal(false);
+    });
+
+    it('with "first" less than the document count', async function() {
+      await populate({}, {}, {}, {}, {});
+
+      const result = await resolver.all({criteria: {}, first: 4});
+      expect(result.edges).to.have.lengthOf(4);
+      expect(result.pageInfo.hasPreviousPage).to.equal(false);
+      expect(result.pageInfo.hasNextPage).to.equal(true);
+    });
+
+    it('with "first" equal to the document count', async function() {
+      await populate({}, {}, {}, {}, {});
+
+      const result = await resolver.all({criteria: {}, first: 5});
+      expect(result.edges).to.have.lengthOf(5);
+      expect(result.pageInfo.hasPreviousPage).to.equal(false);
+      expect(result.pageInfo.hasNextPage).to.equal(false);
+    });
+
+    it('with "first" greater than the document count', async function() {
+      await populate({}, {}, {}, {}, {});
+
+      const result = await resolver.all({criteria: {}, first: 10});
+      expect(result.edges).to.have.lengthOf(5);
+      expect(result.pageInfo.hasPreviousPage).to.equal(false);
+      expect(result.pageInfo.hasNextPage).to.equal(false);
+    });
+
+    it('with "after" less than the first document ID', async function() {
+      await populate({}, {}, {}, {}, {});
+
+      const result = await resolver.all({criteria: {}, after: "0"});
+      expect(result.edges).to.have.lengthOf(5);
+      expect(result.pageInfo.hasPreviousPage).to.equal(false);
+      expect(result.pageInfo.hasNextPage).to.equal(false);
+    });
+
+    it('with "after" as an intermediate document ID', async function() {
+      await populate({}, {}, {}, {}, {});
+
+      const result = await resolver.all({criteria: {}, after: "3"});
+      expect(result.edges).to.have.lengthOf(2);
+      expect(result.pageInfo.hasPreviousPage).to.equal(true);
+      expect(result.pageInfo.hasNextPage).to.equal(false);
+    });
+
+    it('with "after" greater than the last document ID', async function() {
+      await populate({}, {}, {}, {}, {});
+
+      const result = await resolver.all({criteria: {}, after: "10"});
+      expect(result.edges).to.have.lengthOf(0);
+      expect(result.pageInfo.hasPreviousPage).to.equal(true);
+      expect(result.pageInfo.hasNextPage).to.equal(false);
+    });
+
+    it("matching a query", async function() {
+      await populate(
+        {},
+        {},
+        {body: "aaa 0"},
+        {body: "aaa 1"},
+        {body: "2 aaa"},
+        {},
+        {}
+      );
+
+      const result = await resolver.all({criteria: {query: "aaa"}});
+      expect(result.edges).to.have.lengthOf(3);
+      expect(result.edges.map(edge => edge.node.text)).to.have.members([
+        "aaa 0",
+        "aaa 1",
+        "2 aaa",
+      ]);
+      expect(result.pageInfo.hasPreviousPage).to.equal(false);
+      expect(result.pageInfo.hasNextPage).to.equal(false);
+    });
+
+    it("with a matching subject", async function() {
+      await populate(
+        {},
+        {},
+        {body: "yes 0", subject: "me"},
+        {body: "yes 1", subject: "me"},
+        {body: "no 0", subject: "other"},
+        {},
+        {}
+      );
+
+      const result = await resolver.all({criteria: {subject: "me"}});
+      expect(result.edges).to.have.lengthOf(2);
+      expect(result.edges.map(edge => edge.node.text)).to.have.members([
+        "yes 0",
+        "yes 1",
+      ]);
+      expect(result.pageInfo.hasPreviousPage).to.equal(false);
+      expect(result.pageInfo.hasNextPage).to.equal(false);
+    });
+
+    it("with all speakers", async function() {
+      await populate(
+        {},
+        {},
+        {body: "yes 0", speakers: ["me0", "me1"]},
+        {body: "yes 1", speakers: ["me0", "me1"]},
+        {body: "no 0", speakers: ["me1"]},
+        {body: "no 1", speakers: ["me1", "other"]},
+        {body: "no 2", speakers: ["other"]},
+        {},
+        {}
+      );
+
+      const result = await resolver.all({criteria: {speakers: ["me0", "me1"]}});
+      expect(result.edges).to.have.lengthOf(2);
+      expect(result.edges.map(edge => edge.node.text)).to.have.members([
+        "yes 0",
+        "yes 1",
+      ]);
+      expect(result.pageInfo.hasPreviousPage).to.equal(false);
+      expect(result.pageInfo.hasNextPage).to.equal(false);
+    });
+
+    it("with all mentions", async function() {
+      await populate(
+        {},
+        {},
+        {body: "yes 0", mentions: ["me0", "me1"]},
+        {body: "yes 1", mentions: ["me1", "me0"]},
+        {body: "no 0", mentions: ["me1"]},
+        {body: "no 1", mentions: ["me1", "other"]},
+        {body: "no 2", mentions: ["other"]},
+        {},
+        {}
+      );
+
+      const result = await resolver.all({criteria: {mentions: ["me0", "me1"]}});
+      expect(result.edges).to.have.lengthOf(2);
+      expect(result.edges.map(edge => edge.node.text)).to.have.members([
+        "yes 0",
+        "yes 1",
+      ]);
+      expect(result.pageInfo.hasPreviousPage).to.equal(false);
+      expect(result.pageInfo.hasNextPage).to.equal(false);
+    });
+  });
+
+  describe("mine", function() {
+    it("with no documents", async function() {
+      const req = {user: {name: "me"}};
+      const result = await resolver.mine({}, req);
+
+      expect(result.found).to.equal(false);
+    });
+
+    it("with no documents matching the subject of the current user", async function() {
+      await populate({}, {}, {}, {}, {subject: "other"});
+
+      const req = {user: {name: "me"}};
+      const result = await resolver.mine({}, req);
+
+      expect(result.found).to.equal(false);
+    });
+
+    it("with a document matching the subject of the current user", async function() {
+      await populate(
+        {},
+        {},
+        {},
+        {},
+        {body: "yes", subject: "me"},
+        {subject: "other"}
+      );
+
+      const req = {user: {name: "me"}};
+      const result = await resolver.mine({}, req);
+
+      expect(result.found).to.equal(true);
+      expect(result.text).to.equal("yes");
+    });
+  });
+
+  describe("rank", function() {
+    it("with no documents", async function() {
+      const result = await resolver.rank({speaker: "me"});
+      expect(result).to.equal(0);
+    });
+
+    it("with no documents matching with a matching speaker", async function() {
+      await populate({}, {}, {speakers: ["other"]}, {speakers: ["no"]});
+
+      const result = await resolver.rank({speaker: "me"});
+      expect(result).to.equal(0);
+    });
+
+    it("with documents matching the requested speaker", async function() {
+      await populate(
+        {speakers: ["me"]},
+        {speakers: ["me"]},
+        {speakers: ["me"]},
+        {speakers: ["first"]},
+        {speakers: ["first"]},
+        {speakers: ["first"]},
+        {speakers: ["first"]},
+        {speakers: ["last"]},
+        {speakers: ["last"]}
+      );
+
+      const result = await resolver.rank({speaker: "me"});
+      expect(result).to.equal(2);
+    });
+  });
+
+  describe("count", function() {
+    it("with no documents", async function() {
+      const result = await resolver.count({criteria: {}});
+      expect(result).to.equal(0);
+    });
+
+    it("with an empty query", async function() {
+      await populate({}, {}, {});
+
+      const result = await resolver.count({criteria: {}});
+      expect(result).to.equal(3);
+    });
+
+    it("matching a query", async function() {
+      await populate(
+        {},
+        {},
+        {},
+        {body: "yes zzz 0"},
+        {body: "yes 1 zzz"},
+        {},
+        {}
+      );
+
+      const result = await resolver.count({criteria: {query: "zzz"}});
+      expect(result).to.equal(2);
+    });
+
+    it("with a matching subject", async function() {
+      await populate(
+        {},
+        {},
+        {},
+        {subject: "me"},
+        {subject: "me"},
+        {subject: "other"},
+        {},
+        {}
+      );
+
+      const result = await resolver.count({criteria: {subject: "me"}});
+      expect(result).to.equal(2);
+    });
+
+    it("with all speakers", async function() {
+      await populate(
+        {speakers: ["yes0"]},
+        {speakers: ["yes0", "yes1"]},
+        {speakers: ["yes0", "yes1", "extra"]},
+        {speakers: ["no0"]},
+        {}
+      );
+
+      const result = await resolver.count({
+        criteria: {speakers: ["yes0", "yes1"]},
+      });
+      expect(result).to.equal(2);
+    });
+
+    it("with all mentions", async function() {
+      await populate(
+        {mentions: ["yes0"]},
+        {mentions: ["yes0", "yes1"]},
+        {mentions: ["yes0", "yes1", "extra"]},
+        {mentions: ["no0"]},
+        {}
+      );
+
+      const result = await resolver.count({
+        criteria: {mentions: ["yes0", "yes1"]},
+      });
+      expect(result).to.equal(2);
+    });
+  });
+});

--- a/test/api/mutations.test.js
+++ b/test/api/mutations.test.js
@@ -1,159 +1,181 @@
-const Helper = require('hubot-test-helper')
-const moment = require('moment-timezone')
-const { createDocumentSet } = require('../../scripts/documentset')
-const cache = require('../../scripts/models/cache')
+const Helper = require("hubot-test-helper");
+const moment = require("moment-timezone");
+const {createDocumentSet} = require("../../scripts/documentset");
+const cache = require("../../scripts/models/cache");
 
-const resolver = require('../../scripts/api/root')
+const resolver = require("../../scripts/api/root");
 
-const helper = new Helper([])
+const helper = new Helper([]);
 
-const ts = moment.tz('2017-10-16 21:30:00-0400', 'America/New_York')
+const ts = moment.tz("2017-10-16 21:30:00-0400", "America/New_York");
 
-describe('GraphQL mutations', function () {
-  let room, blarfSet
-  let authorized, unauthorized
+describe("GraphQL mutations", function() {
+  let room, blarfSet;
+  let authorized, unauthorized;
 
-  beforeEach(function () {
-    usesDatabase(this)
-    cache.clear()
+  beforeEach(function() {
+    usesDatabase(this);
+    cache.clear();
 
-    room = helper.createRoom({ httpd: false, name: 'C100' })
-    room.robot.postgres = global.database
+    room = helper.createRoom({httpd: false, name: "C100"});
+    room.robot.postgres = global.database;
 
-    authorized = room.robot.brain.userForId('1', { name: 'authy' })
-    unauthorized = room.robot.brain.userForId('2', { name: 'fenris' })
+    authorized = room.robot.brain.userForId("1", {name: "authy"});
+    unauthorized = room.robot.brain.userForId("2", {name: "fenris"});
 
-    blarfSet = createDocumentSet(room.robot, 'blarf', {
+    blarfSet = createDocumentSet(room.robot, "blarf", {
       add: {
-        role: { isAllowed (robot, user) { return user === authorized } }
-      }
-    })
-  })
+        role: {
+          isAllowed(robot, user) {
+            return user === authorized;
+          },
+        },
+      },
+    });
+  });
 
-  afterEach(function () {
-    room.destroy()
-    return blarfSet.destroy()
-  })
+  afterEach(function() {
+    room.destroy();
+    return blarfSet.destroy();
+  });
 
-  describe('createDocument', function () {
-    let lineIDs
+  describe("createDocument", function() {
+    let lineIDs;
 
-    beforeEach(function () {
-      const c = cache.forChannel(room.robot, 'C100')
-        .append(message('aaa', 'line one'), ts)
-        .append(message('bbb', 'line two\nline three'), ts)
-        .append(message('ccc', 'line four'), ts)
+    beforeEach(function() {
+      const c = cache
+        .forChannel(room.robot, "C100")
+        .append(message("aaa", "line one"), ts)
+        .append(message("bbb", "line two\nline three"), ts)
+        .append(message("ccc", "line four"), ts);
 
-      lineIDs = c.lines.map(line => line.id)
-      lineIDs.reverse()
+      lineIDs = c.lines.map(line => line.id);
+      lineIDs.reverse();
 
       room.robot.adapter.client = {
         rtm: {
           dataStore: {
-            getChannelByName (name) {
-              if (name === 'general') return { id: 'C100' }
-              return undefined
-            }
-          }
-        }
-      }
-    })
+            getChannelByName(name) {
+              if (name === "general") return {id: "C100"};
+              return undefined;
+            },
+          },
+        },
+      };
+    });
 
-    it('rejects a request from a user without the required role', function () {
-      return resolver.createDocument(
-        { set: 'blarf', channel: 'C100', lines: [lineIDs[0]] },
-        { robot: room.robot, user: unauthorized }
-      ).then(() => new Error('Did not reject'), err => expect(err.message).to.match(/not authorized/))
-    })
+    it("rejects a request from a user without the required role", function() {
+      return resolver
+        .createDocument(
+          {set: "blarf", channel: "C100", lines: [lineIDs[0]]},
+          {robot: room.robot, user: unauthorized}
+        )
+        .then(
+          () => new Error("Did not reject"),
+          err => expect(err.message).to.match(/not authorized/)
+        );
+    });
 
-    it('rejects a request with an invalid line ID', function () {
-      return resolver.createDocument(
-        { set: 'blarf', channel: 'C100', lines: ['no'] },
-        { robot: room.robot, user: authorized }
-      ).then(() => new Error('Did not reject'), err => expect(err.message).to.match(/no/))
-    })
+    it("rejects a request with an invalid line ID", function() {
+      return resolver
+        .createDocument(
+          {set: "blarf", channel: "C100", lines: ["no"]},
+          {robot: room.robot, user: authorized}
+        )
+        .then(
+          () => new Error("Did not reject"),
+          err => expect(err.message).to.match(/no/)
+        );
+    });
 
-    it('rejects a request with an invalid channel', function () {
-      return resolver.createDocument(
-        { set: 'blarf', channel: 'nope', lines: [lineIDs[0]] },
-        { robot: room.robot, user: authorized }
-      ).then(() => new Error('Did not reject'), err => expect(err.message).to.match(/nope/))
-    })
+    it("rejects a request with an invalid channel", function() {
+      return resolver
+        .createDocument(
+          {set: "blarf", channel: "nope", lines: [lineIDs[0]]},
+          {robot: room.robot, user: authorized}
+        )
+        .then(
+          () => new Error("Did not reject"),
+          err => expect(err.message).to.match(/nope/)
+        );
+    });
 
-    it('rejects requests with an empty line array', function () {
-      return resolver.createDocument(
-        { set: 'blarf', channel: 'C100', lines: [] },
-        { robot: room.robot, user: authorized }
-      ).then(() => new Error('Did not reject'), err => expect(err.message).to.match(/at least one line/))
-    })
+    it("rejects requests with an empty line array", function() {
+      return resolver
+        .createDocument(
+          {set: "blarf", channel: "C100", lines: []},
+          {robot: room.robot, user: authorized}
+        )
+        .then(
+          () => new Error("Did not reject"),
+          err => expect(err.message).to.match(/at least one line/)
+        );
+    });
 
-    it('adds a document from the cache', async function () {
+    it("adds a document from the cache", async function() {
       const docResolver = await resolver.createDocument(
-        { set: 'blarf', channel: 'C100', lines: [lineIDs[1], lineIDs[2]] },
-        { robot: room.robot, user: authorized }
-      )
+        {set: "blarf", channel: "C100", lines: [lineIDs[1], lineIDs[2]]},
+        {robot: room.robot, user: authorized}
+      );
 
-      expect(docResolver.found).to.be.true
+      expect(docResolver.found).to.be.true;
       expect(docResolver.text).to.equal(
-        '[9:30 PM 16 Oct 2017] bbb: line two\n' +
-        '[9:30 PM 16 Oct 2017] bbb: line three'
-      )
-      expect(docResolver.speakers()).to.have.members(['bbb'])
-      expect(docResolver.mentions()).to.be.empty
+        "[9:30 PM 16 Oct 2017] bbb: line two\n" +
+          "[9:30 PM 16 Oct 2017] bbb: line three"
+      );
+      expect(docResolver.speakers()).to.have.members(["bbb"]);
+      expect(docResolver.mentions()).to.be.empty;
 
-      const doc = await blarfSet.singleMatching({ speaker: ['bbb'] })
-      expect(doc.wasFound()).to.be.true
-      expect(doc.id).to.equal(docResolver.id)
-      expect(doc.getBody()).to.equal(docResolver.text)
-    })
+      const doc = await blarfSet.singleMatching({speaker: ["bbb"]});
+      expect(doc.wasFound()).to.be.true;
+      expect(doc.id).to.equal(docResolver.id);
+      expect(doc.getBody()).to.equal(docResolver.text);
+    });
 
-    it('announces the quoting user to the channel', async function () {
+    it("announces the quoting user to the channel", async function() {
       await resolver.createDocument(
-        { set: 'blarf', channel: 'C100', lines: [lineIDs[1], lineIDs[3]] },
-        { robot: room.robot, user: authorized }
-      )
+        {set: "blarf", channel: "C100", lines: [lineIDs[1], lineIDs[3]]},
+        {robot: room.robot, user: authorized}
+      );
 
       expect(room.messages).to.deep.equal([
-        [
-          'hubot',
-          '_<@1> quoted_\n' +
-          '> bbb: line two\n' +
-          '> ccc: line four'
-        ]
-      ])
-    })
+        ["hubot", "_<@1> quoted_\n" + "> bbb: line two\n" + "> ccc: line four"],
+      ]);
+    });
 
-    it('preserves the channel order cache of the chosen lines', async function () {
+    it("preserves the channel order cache of the chosen lines", async function() {
       const docResolver = await resolver.createDocument(
-        { set: 'blarf', channel: 'C100', lines: [lineIDs[2], lineIDs[3], lineIDs[1]] },
-        { robot: room.robot, user: authorized }
-      )
+        {
+          set: "blarf",
+          channel: "C100",
+          lines: [lineIDs[2], lineIDs[3], lineIDs[1]],
+        },
+        {robot: room.robot, user: authorized}
+      );
 
-      expect(docResolver.found).to.be.true
+      expect(docResolver.found).to.be.true;
       expect(docResolver.text).to.equal(
-        '[9:30 PM 16 Oct 2017] bbb: line two\n' +
-        '[9:30 PM 16 Oct 2017] bbb: line three\n' +
-        '[9:30 PM 16 Oct 2017] ccc: line four'
-      )
-      expect(docResolver.speakers()).to.have.members(['bbb', 'ccc'])
-      expect(docResolver.mentions()).to.be.empty
+        "[9:30 PM 16 Oct 2017] bbb: line two\n" +
+          "[9:30 PM 16 Oct 2017] bbb: line three\n" +
+          "[9:30 PM 16 Oct 2017] ccc: line four"
+      );
+      expect(docResolver.speakers()).to.have.members(["bbb", "ccc"]);
+      expect(docResolver.mentions()).to.be.empty;
 
-      const doc = await blarfSet.singleMatching({ speaker: ['bbb'] })
-      expect(doc.wasFound()).to.be.true
-      expect(doc.id).to.equal(docResolver.id)
-      expect(doc.getBody()).to.equal(docResolver.text)
-    })
+      const doc = await blarfSet.singleMatching({speaker: ["bbb"]});
+      expect(doc.wasFound()).to.be.true;
+      expect(doc.id).to.equal(docResolver.id);
+      expect(doc.getBody()).to.equal(docResolver.text);
+    });
 
-    it('chooses a channel by ID or name', async function () {
+    it("chooses a channel by ID or name", async function() {
       const docResolver = await resolver.createDocument(
-        { set: 'blarf', channel: 'general', lines: [lineIDs[0]] },
-        { robot: room.robot, user: authorized }
-      )
+        {set: "blarf", channel: "general", lines: [lineIDs[0]]},
+        {robot: room.robot, user: authorized}
+      );
 
-      expect(docResolver.found).to.be.true
-      expect(docResolver.text).to.equal(
-        '[9:30 PM 16 Oct 2017] aaa: line one'
-      )
-    })
-  })
-})
+      expect(docResolver.found).to.be.true;
+      expect(docResolver.text).to.equal("[9:30 PM 16 Oct 2017] aaa: line one");
+    });
+  });
+});

--- a/test/api/rem.test.js
+++ b/test/api/rem.test.js
@@ -1,6 +1,6 @@
 const {RemResolver} = require("../../scripts/api/rem");
 
-describe.only("RemResolver", function() {
+describe("RemResolver", function() {
   let bot, resolver, req;
   let authorized, unauthorized;
 

--- a/test/api/rem.test.js
+++ b/test/api/rem.test.js
@@ -13,18 +13,18 @@ describe("RemResolver", function() {
     bot.createUser("1", "admin");
     authorized = bot.createUser("2", "authorized");
 
-    await bot.say("admin", "@hubot rem aaa 000 = value 0");
-    await bot.waitForResponse(`@admin :ok_hand: I've learned "aaa 000".`);
-    await bot.say("admin", "@hubot rem aaa 111 = value 1");
-    await bot.waitForResponse(`@admin :ok_hand: I've learned "aaa 111".`);
-    await bot.say("admin", "@hubot rem aaa 222 = value 2");
-    await bot.waitForResponse(`@admin :ok_hand: I've learned "aaa 222".`);
     await bot.say("admin", "@hubot rem bbb 000 = value 3");
     await bot.waitForResponse(`@admin :ok_hand: I've learned "bbb 000".`);
     await bot.say("admin", "@hubot rem bbb 111 = value 4");
     await bot.waitForResponse(`@admin :ok_hand: I've learned "bbb 111".`);
     await bot.say("admin", "@hubot rem bbb 222 = value 5");
     await bot.waitForResponse(`@admin :ok_hand: I've learned "bbb 222".`);
+    await bot.say("admin", "@hubot rem aaa 000 = value 0");
+    await bot.waitForResponse(`@admin :ok_hand: I've learned "aaa 000".`);
+    await bot.say("admin", "@hubot rem aaa 111 = value 1");
+    await bot.waitForResponse(`@admin :ok_hand: I've learned "aaa 111".`);
+    await bot.say("admin", "@hubot rem aaa 222 = value 2");
+    await bot.waitForResponse(`@admin :ok_hand: I've learned "aaa 222".`);
 
     req = {robot: bot.getRobot(), user: authorized};
     resolver = new RemResolver();
@@ -93,6 +93,129 @@ describe("RemResolver", function() {
         },
         edges: [{cursor: "5", node: {key: "bbb 222", value: "value 5"}}],
       });
+    });
+
+    describe("ordered lexicographically by key", function() {
+      it("ascending", function() {
+        const page0 = resolver.search(
+          {first: 2, orderField: "KEY", orderDirection: "ASCENDING"},
+          req
+        );
+
+        expect(page0).to.deep.equal({
+          pageInfo: {
+            hasPreviousPage: false,
+            hasNextPage: true,
+            total: 6,
+          },
+          edges: [
+            {cursor: "0", node: {key: "aaa 000", value: "value 0"}},
+            {cursor: "1", node: {key: "aaa 111", value: "value 1"}},
+          ],
+        });
+
+        const page1 = resolver.search(
+          {
+            first: 2,
+            after: "1",
+            orderField: "KEY",
+            orderDirection: "ASCENDING",
+          },
+          req
+        );
+        expect(page1).to.deep.equal({
+          pageInfo: {
+            hasPreviousPage: true,
+            hasNextPage: true,
+            total: 6,
+          },
+          edges: [
+            {cursor: "2", node: {key: "aaa 222", value: "value 2"}},
+            {cursor: "3", node: {key: "bbb 000", value: "value 3"}},
+          ],
+        });
+
+        const page2 = resolver.search(
+          {
+            first: 2,
+            after: "3",
+            orderField: "KEY",
+            orderDirection: "ASCENDING",
+          },
+          req
+        );
+        expect(page2).to.deep.equal({
+          pageInfo: {
+            hasPreviousPage: true,
+            hasNextPage: false,
+            total: 6,
+          },
+          edges: [
+            {cursor: "4", node: {key: "bbb 111", value: "value 4"}},
+            {cursor: "5", node: {key: "bbb 222", value: "value 5"}},
+          ],
+        });
+      });
+
+      it("descending", function() {
+        const page0 = resolver.search(
+          {first: 3, orderField: "KEY", orderDirection: "DESCENDING"},
+          req
+        );
+
+        expect(page0).to.deep.equal({
+          pageInfo: {
+            hasPreviousPage: false,
+            hasNextPage: true,
+            total: 6,
+          },
+          edges: [
+            {cursor: "0", node: {key: "bbb 222", value: "value 5"}},
+            {cursor: "1", node: {key: "bbb 111", value: "value 4"}},
+            {cursor: "2", node: {key: "bbb 000", value: "value 3"}},
+          ],
+        });
+
+        const page1 = resolver.search(
+          {
+            first: 3,
+            after: "2",
+            orderField: "KEY",
+            orderDirection: "DESCENDING",
+          },
+          req
+        );
+        expect(page1).to.deep.equal({
+          pageInfo: {
+            hasPreviousPage: true,
+            hasNextPage: false,
+            total: 6,
+          },
+          edges: [
+            {cursor: "3", node: {key: "aaa 222", value: "value 2"}},
+            {cursor: "4", node: {key: "aaa 111", value: "value 1"}},
+            {cursor: "5", node: {key: "aaa 000", value: "value 0"}},
+          ],
+        });
+      });
+    });
+
+    it("orders results randomly", function() {
+      const page0 = resolver.search({first: 10, orderField: "RANDOM"}, req);
+
+      expect(page0.pageInfo).to.deep.equal({
+        hasPreviousPage: false,
+        hasNextPage: false,
+        total: 6,
+      });
+      expect(page0.edges).to.have.length(6);
+      const nodes = page0.edges.map(e => e.node);
+      expect(nodes).to.deep.include({key: "aaa 000", value: "value 0"});
+      expect(nodes).to.deep.include({key: "aaa 111", value: "value 1"});
+      expect(nodes).to.deep.include({key: "aaa 222", value: "value 2"});
+      expect(nodes).to.deep.include({key: "bbb 000", value: "value 3"});
+      expect(nodes).to.deep.include({key: "bbb 111", value: "value 4"});
+      expect(nodes).to.deep.include({key: "bbb 222", value: "value 5"});
     });
   });
 });

--- a/test/api/rem.test.js
+++ b/test/api/rem.test.js
@@ -58,7 +58,7 @@ describe("RemResolver", function() {
         pageInfo: {
           hasPreviousPage: false,
           hasNextPage: false,
-          total: 2,
+          count: 2,
         },
         edges: [
           {cursor: "0", node: {key: "aaa 111", value: "value 1"}},
@@ -73,7 +73,7 @@ describe("RemResolver", function() {
         pageInfo: {
           hasPreviousPage: false,
           hasNextPage: true,
-          total: 6,
+          count: 6,
         },
         edges: [
           {cursor: "0", node: {key: "aaa 000", value: "value 0"}},
@@ -89,7 +89,7 @@ describe("RemResolver", function() {
         pageInfo: {
           hasPreviousPage: true,
           hasNextPage: false,
-          total: 6,
+          count: 6,
         },
         edges: [{cursor: "5", node: {key: "bbb 222", value: "value 5"}}],
       });
@@ -106,7 +106,7 @@ describe("RemResolver", function() {
           pageInfo: {
             hasPreviousPage: false,
             hasNextPage: true,
-            total: 6,
+            count: 6,
           },
           edges: [
             {cursor: "0", node: {key: "aaa 000", value: "value 0"}},
@@ -127,7 +127,7 @@ describe("RemResolver", function() {
           pageInfo: {
             hasPreviousPage: true,
             hasNextPage: true,
-            total: 6,
+            count: 6,
           },
           edges: [
             {cursor: "2", node: {key: "aaa 222", value: "value 2"}},
@@ -148,7 +148,7 @@ describe("RemResolver", function() {
           pageInfo: {
             hasPreviousPage: true,
             hasNextPage: false,
-            total: 6,
+            count: 6,
           },
           edges: [
             {cursor: "4", node: {key: "bbb 111", value: "value 4"}},
@@ -167,7 +167,7 @@ describe("RemResolver", function() {
           pageInfo: {
             hasPreviousPage: false,
             hasNextPage: true,
-            total: 6,
+            count: 6,
           },
           edges: [
             {cursor: "0", node: {key: "bbb 222", value: "value 5"}},
@@ -189,7 +189,7 @@ describe("RemResolver", function() {
           pageInfo: {
             hasPreviousPage: true,
             hasNextPage: false,
-            total: 6,
+            count: 6,
           },
           edges: [
             {cursor: "3", node: {key: "aaa 222", value: "value 2"}},
@@ -206,7 +206,7 @@ describe("RemResolver", function() {
       expect(page0.pageInfo).to.deep.equal({
         hasPreviousPage: false,
         hasNextPage: false,
-        total: 6,
+        count: 6,
       });
       expect(page0.edges).to.have.length(6);
       const nodes = page0.edges.map(e => e.node);

--- a/test/api/rem.test.js
+++ b/test/api/rem.test.js
@@ -1,0 +1,98 @@
+const {RemResolver} = require("../../scripts/api/rem");
+
+describe.only("RemResolver", function() {
+  let bot, resolver, req;
+  let authorized, unauthorized;
+
+  beforeEach(async function() {
+    bot = new BotContext("../scripts/rem.js");
+    await bot.loadAuth("1");
+
+    usesDatabase(this);
+
+    bot.createUser("1", "admin");
+    authorized = bot.createUser("2", "authorized");
+
+    await bot.say("admin", "@hubot rem aaa 000 = value 0");
+    await bot.waitForResponse(`@admin :ok_hand: I've learned "aaa 000".`);
+    await bot.say("admin", "@hubot rem aaa 111 = value 1");
+    await bot.waitForResponse(`@admin :ok_hand: I've learned "aaa 111".`);
+    await bot.say("admin", "@hubot rem aaa 222 = value 2");
+    await bot.waitForResponse(`@admin :ok_hand: I've learned "aaa 222".`);
+    await bot.say("admin", "@hubot rem bbb 000 = value 3");
+    await bot.waitForResponse(`@admin :ok_hand: I've learned "bbb 000".`);
+    await bot.say("admin", "@hubot rem bbb 111 = value 4");
+    await bot.waitForResponse(`@admin :ok_hand: I've learned "bbb 111".`);
+    await bot.say("admin", "@hubot rem bbb 222 = value 5");
+    await bot.waitForResponse(`@admin :ok_hand: I've learned "bbb 222".`);
+
+    req = {robot: bot.getRobot(), user: authorized};
+    resolver = new RemResolver();
+  });
+
+  afterEach(function() {
+    bot.destroy();
+  });
+
+  describe("get", function() {
+    it("retrieves a specific key", function() {
+      expect(
+        resolver.get(
+          {key: "bbb 000"},
+          {robot: bot.getRobot(), user: authorized}
+        )
+      ).to.deep.equal({key: "bbb 000", value: "value 3"});
+    });
+
+    it("returns null if the key is not known", function() {
+      expect(
+        resolver.get({key: "nope"}, {robot: bot.getRobot(), user: authorized})
+      ).to.be.null;
+    });
+  });
+
+  describe("search", function() {
+    it("lists matching keys and values in a paginated connection", function() {
+      const result = resolver.search({query: "111", first: 10}, req);
+      expect(result).to.deep.equal({
+        pageInfo: {
+          hasPreviousPage: false,
+          hasNextPage: false,
+          total: 2,
+        },
+        edges: [
+          {cursor: "0", node: {key: "aaa 111", value: "value 1"}},
+          {cursor: "1", node: {key: "bbb 111", value: "value 4"}},
+        ],
+      });
+    });
+
+    it("lists all keys and values in a paginated connection", function() {
+      const page0 = resolver.search({first: 5}, req);
+      expect(page0).to.deep.equal({
+        pageInfo: {
+          hasPreviousPage: false,
+          hasNextPage: true,
+          total: 6,
+        },
+        edges: [
+          {cursor: "0", node: {key: "aaa 000", value: "value 0"}},
+          {cursor: "1", node: {key: "aaa 111", value: "value 1"}},
+          {cursor: "2", node: {key: "aaa 222", value: "value 2"}},
+          {cursor: "3", node: {key: "bbb 000", value: "value 3"}},
+          {cursor: "4", node: {key: "bbb 111", value: "value 4"}},
+        ],
+      });
+
+      const page1 = resolver.search({first: 5, after: "4"}, req);
+      expect(page1).to.deep.equal({
+        pageInfo: {
+          hasPreviousPage: true,
+          hasNextPage: false,
+          total: 6,
+        },
+        edges: [{cursor: "5", node: {key: "bbb 222", value: "value 5"}}],
+      });
+    });
+  });
+});

--- a/test/api/user-set.test.js
+++ b/test/api/user-set.test.js
@@ -1,179 +1,185 @@
-const { UserSetResolver } = require('../../scripts/api/user-set')
+const {UserSetResolver} = require("../../scripts/api/user-set");
 
-describe('UserSetResolver', function () {
-  let bot, self, req, resolver
+describe("UserSetResolver", function() {
+  let bot, self, req, resolver;
 
-  beforeEach(async function () {
-    bot = new BotContext()
-    await bot.loadAuth('1')
+  beforeEach(async function() {
+    bot = new BotContext();
+    await bot.loadAuth("1");
 
-    self = bot.createUser('1', 'self', { roles: ['role one', 'role two'] })
-    bot.createUser('2', 'two')
-    bot.createUser('3', 'three')
+    self = bot.createUser("1", "self", {roles: ["role one", "role two"]});
+    bot.createUser("2", "two");
+    bot.createUser("3", "three");
 
-    req = { robot: bot.getRobot(), user: self }
-    resolver = new UserSetResolver()
-  })
+    req = {robot: bot.getRobot(), user: self};
+    resolver = new UserSetResolver();
+  });
 
-  afterEach(function () {
-    bot.destroy()
-  })
+  afterEach(function() {
+    bot.destroy();
+  });
 
-  describe('me', function () {
-    it('returns a resolver for a user from the request', function () {
-      const result = resolver.me({}, req)
-      expect(result.user).to.eql(self)
-    })
-  })
+  describe("me", function() {
+    it("returns a resolver for a user from the request", function() {
+      const result = resolver.me({}, req);
+      expect(result.user).to.eql(self);
+    });
+  });
 
-  describe('all', function () {
-    it('returns resolvers for all users', function () {
-      const results = resolver.all({}, req)
+  describe("all", function() {
+    it("returns resolvers for all users", function() {
+      const results = resolver.all({}, req);
       expect(results.map(each => each.user)).to.have.deep.members([
-        { id: '1', name: 'self', roles: ['role one', 'role two'] },
-        { id: '2', name: 'two' },
-        { id: '3', name: 'three' }
-      ])
-    })
-  })
+        {id: "1", name: "self", roles: ["role one", "role two"]},
+        {id: "2", name: "two"},
+        {id: "3", name: "three"},
+      ]);
+    });
+  });
 
-  describe('withName', function () {
-    it('returns a resolver for a user by name', function () {
-      const result = resolver.withName({ name: 'two' }, req)
-      expect(result.user.id).to.eql('2')
-    })
+  describe("withName", function() {
+    it("returns a resolver for a user by name", function() {
+      const result = resolver.withName({name: "two"}, req);
+      expect(result.user.id).to.eql("2");
+    });
 
-    it('return null if no such user exists', function () {
-      const result = resolver.withName({ name: 'snorgle' }, req)
-      expect(result).to.eql(null)
-    })
-  })
+    it("return null if no such user exists", function() {
+      const result = resolver.withName({name: "snorgle"}, req);
+      expect(result).to.eql(null);
+    });
+  });
 
-  describe('UserResolver', function () {
-    it('reports static properties directly from the User model', function () {
-      self.real_name = 'Real Name'
-      self.slack = { tz: 'America/New_York', presence: 'active' }
+  describe("UserResolver", function() {
+    it("reports static properties directly from the User model", function() {
+      self.real_name = "Real Name";
+      self.slack = {tz: "America/New_York", presence: "active"};
 
-      const userResolver = resolver.me({}, req)
+      const userResolver = resolver.me({}, req);
 
-      expect(userResolver.id).to.eql('1')
-      expect(userResolver.name).to.eql('self')
-      expect(userResolver.realName).to.eql('Real Name')
-      expect(userResolver.timezone).to.eql('America/New_York')
-      expect(userResolver.presence).to.eql('ACTIVE')
-    })
+      expect(userResolver.id).to.eql("1");
+      expect(userResolver.name).to.eql("self");
+      expect(userResolver.realName).to.eql("Real Name");
+      expect(userResolver.timezone).to.eql("America/New_York");
+      expect(userResolver.presence).to.eql("ACTIVE");
+    });
 
-    it('defaults missing attributes', function () {
-      const userResolver = resolver.me({}, req)
+    it("defaults missing attributes", function() {
+      const userResolver = resolver.me({}, req);
 
-      expect(userResolver.id).to.eql('1')
-      expect(userResolver.name).to.eql('self')
-      expect(userResolver.realName).to.eql(undefined)
-      expect(userResolver.timezone).to.eql(undefined)
-      expect(userResolver.presence).to.eql('UNKNOWN')
-    })
+      expect(userResolver.id).to.eql("1");
+      expect(userResolver.name).to.eql("self");
+      expect(userResolver.realName).to.eql(undefined);
+      expect(userResolver.timezone).to.eql(undefined);
+      expect(userResolver.presence).to.eql("UNKNOWN");
+    });
 
-    it("returns a resolver for the user's status", function () {
+    it("returns a resolver for the user's status", function() {
       self.slack = {
         profile: {
-          status_text: 'here',
-          status_emoji: ':coffee:'
-        }
-      }
+          status_text: "here",
+          status_emoji: ":coffee:",
+        },
+      };
 
-      const userResolver = resolver.me({}, req)
-      const statusResolver = userResolver.status()
+      const userResolver = resolver.me({}, req);
+      const statusResolver = userResolver.status();
 
-      expect(statusResolver.message).to.eql('here')
-      expect(statusResolver.emoji).to.eql(':coffee:')
-    })
+      expect(statusResolver.message).to.eql("here");
+      expect(statusResolver.emoji).to.eql(":coffee:");
+    });
 
-    it('returns an empty resolver if no status exists', function () {
-      const userResolver = resolver.me({}, req)
-      const statusResolver = userResolver.status()
+    it("returns an empty resolver if no status exists", function() {
+      const userResolver = resolver.me({}, req);
+      const statusResolver = userResolver.status();
 
-      expect(statusResolver.message).to.eql(undefined)
-      expect(statusResolver.emoji).to.eql(undefined)
-    })
+      expect(statusResolver.message).to.eql(undefined);
+      expect(statusResolver.emoji).to.eql(undefined);
+    });
 
-    it("returns a resolver for the user's avatar", function () {
+    it("returns a resolver for the user's avatar", function() {
       self.slack = {
         profile: {
-          image_24: 'https://localhost/avatar24.jpg',
-          image_32: 'https://localhost/avatar32.jpg',
-          image_48: 'https://localhost/avatar48.jpg',
-          image_72: 'https://localhost/avatar72.jpg',
-          image_192: 'https://localhost/avatar192.jpg',
-          image_512: 'https://localhost/avatar512.jpg',
-          image_1024: 'https://localhost/avatar1024.jpg'
-        }
-      }
+          image_24: "https://localhost/avatar24.jpg",
+          image_32: "https://localhost/avatar32.jpg",
+          image_48: "https://localhost/avatar48.jpg",
+          image_72: "https://localhost/avatar72.jpg",
+          image_192: "https://localhost/avatar192.jpg",
+          image_512: "https://localhost/avatar512.jpg",
+          image_1024: "https://localhost/avatar1024.jpg",
+        },
+      };
 
-      const userResolver = resolver.me({}, req)
-      const avatarResolver = userResolver.avatar()
+      const userResolver = resolver.me({}, req);
+      const avatarResolver = userResolver.avatar();
 
-      expect(avatarResolver.image24).to.eql('https://localhost/avatar24.jpg')
-      expect(avatarResolver.image32).to.eql('https://localhost/avatar32.jpg')
-      expect(avatarResolver.image48).to.eql('https://localhost/avatar48.jpg')
-      expect(avatarResolver.image72).to.eql('https://localhost/avatar72.jpg')
-      expect(avatarResolver.image192).to.eql('https://localhost/avatar192.jpg')
-      expect(avatarResolver.image512).to.eql('https://localhost/avatar512.jpg')
-      expect(avatarResolver.image1024).to.eql('https://localhost/avatar1024.jpg')
-    })
+      expect(avatarResolver.image24).to.eql("https://localhost/avatar24.jpg");
+      expect(avatarResolver.image32).to.eql("https://localhost/avatar32.jpg");
+      expect(avatarResolver.image48).to.eql("https://localhost/avatar48.jpg");
+      expect(avatarResolver.image72).to.eql("https://localhost/avatar72.jpg");
+      expect(avatarResolver.image192).to.eql("https://localhost/avatar192.jpg");
+      expect(avatarResolver.image512).to.eql("https://localhost/avatar512.jpg");
+      expect(avatarResolver.image1024).to.eql(
+        "https://localhost/avatar1024.jpg"
+      );
+    });
 
-    it('returns an empty resolver if no avatar exists', function () {
-      const userResolver = resolver.me({}, req)
-      const avatarResolver = userResolver.avatar()
+    it("returns an empty resolver if no avatar exists", function() {
+      const userResolver = resolver.me({}, req);
+      const avatarResolver = userResolver.avatar();
 
-      expect(avatarResolver.image24).to.eql(undefined)
-      expect(avatarResolver.image32).to.eql(undefined)
-      expect(avatarResolver.image48).to.eql(undefined)
-      expect(avatarResolver.image72).to.eql(undefined)
-      expect(avatarResolver.image192).to.eql(undefined)
-      expect(avatarResolver.image512).to.eql(undefined)
-      expect(avatarResolver.image1024).to.eql(undefined)
-    })
+      expect(avatarResolver.image24).to.eql(undefined);
+      expect(avatarResolver.image32).to.eql(undefined);
+      expect(avatarResolver.image48).to.eql(undefined);
+      expect(avatarResolver.image72).to.eql(undefined);
+      expect(avatarResolver.image192).to.eql(undefined);
+      expect(avatarResolver.image512).to.eql(undefined);
+      expect(avatarResolver.image1024).to.eql(undefined);
+    });
 
-    it('accesses currently assigned roles', function () {
-      const userResolver = resolver.me({}, req)
-      const roles = userResolver.roles({}, req)
+    it("accesses currently assigned roles", function() {
+      const userResolver = resolver.me({}, req);
+      const roles = userResolver.roles({}, req);
       expect(roles).to.eql([
-        { name: 'admin' },
-        { name: 'role one' },
-        { name: 'role two' }
-      ])
-    })
+        {name: "admin"},
+        {name: "role one"},
+        {name: "role two"},
+      ]);
+    });
 
-    it('accesses counts of reactions given', async function () {
-      bot.store('reactionsGiven', {
-        '1': {
+    it("accesses counts of reactions given", async function() {
+      bot.store("reactionsGiven", {
+        "1": {
           yellow_heart: 10,
           sparkles: 7,
-          partyparrot: 5
-        }
-      })
+          partyparrot: 5,
+        },
+      });
 
-      const given = await resolver.me({}, req).topReactionsGiven({ limit: 2 }, req)
+      const given = await resolver
+        .me({}, req)
+        .topReactionsGiven({limit: 2}, req);
       expect(given).to.deep.equal([
-        { count: 10, emoji: { name: 'yellow_heart', url: null } },
-        { count: 7, emoji: { name: 'sparkles', url: null } }
-      ])
-    })
+        {count: 10, emoji: {name: "yellow_heart", url: null}},
+        {count: 7, emoji: {name: "sparkles", url: null}},
+      ]);
+    });
 
-    it('accesses counts of reactions received', async function () {
-      bot.store('reactionsReceived', {
-        '1': {
+    it("accesses counts of reactions received", async function() {
+      bot.store("reactionsReceived", {
+        "1": {
           boom: 50,
           heart: 18,
-          partyparrot: 5
-        }
-      })
+          partyparrot: 5,
+        },
+      });
 
-      const received = await resolver.me({}, req).topReactionsReceived({ limit: 2 }, req)
+      const received = await resolver
+        .me({}, req)
+        .topReactionsReceived({limit: 2}, req);
       expect(received).to.deep.equal([
-        { count: 50, emoji: { name: 'boom', url: null } },
-        { count: 18, emoji: { name: 'heart', url: null } }
-      ])
-    })
-  })
-})
+        {count: 50, emoji: {name: "boom", url: null}},
+        {count: 18, emoji: {name: "heart", url: null}},
+      ]);
+    });
+  });
+});

--- a/test/models/buffer.test.js
+++ b/test/models/buffer.test.js
@@ -1,119 +1,136 @@
-const moment = require('moment-timezone')
+const moment = require("moment-timezone");
 
-const Helper = require('hubot-test-helper')
-const helper = new Helper([])
+const Helper = require("hubot-test-helper");
+const helper = new Helper([]);
 
-const Buffer = require('../../scripts/models/buffer')
-const Line = require('../../scripts/models/line')
+const Buffer = require("../../scripts/models/buffer");
+const Line = require("../../scripts/models/line");
 
-describe('Buffer', function () {
-  let room, buffer
+describe("Buffer", function() {
+  let room, buffer;
 
-  beforeEach(function () {
-    room = helper.createRoom({ httpd: false })
-    buffer = Buffer.forUser(room.robot, 'U123')
-  })
+  beforeEach(function() {
+    room = helper.createRoom({httpd: false});
+    buffer = Buffer.forUser(room.robot, "U123");
+  });
 
-  afterEach(function () {
-    room.destroy()
-    Buffer.clear()
-  })
+  afterEach(function() {
+    room.destroy();
+    Buffer.clear();
+  });
 
-  function makeLine (text, minute, speaker = 'me') {
+  function makeLine(text, minute, speaker = "me") {
     return new Line(
-      moment.tz({ year: 2017, month: 5, day: 10, hour: 9, minute }, 'America/New_York'),
+      moment.tz(
+        {year: 2017, month: 5, day: 10, hour: 9, minute},
+        "America/New_York"
+      ),
       speaker,
       text
-    )
+    );
   }
 
-  function makeLines (texts, speaker = 'me') {
-    return texts.map((text, i) => makeLine(text, i, speaker))
+  function makeLines(texts, speaker = "me") {
+    return texts.map((text, i) => makeLine(text, i, speaker));
   }
 
-  it('appends new lines', function () {
-    buffer.append(makeLines(['one one one', 'two two two']))
+  it("appends new lines", function() {
+    buffer.append(makeLines(["one one one", "two two two"]));
 
-    expect(buffer.contents).to.have.length(2)
-    expect(buffer.contents[0].text).to.equal('one one one')
-    expect(buffer.contents[1].text).to.equal('two two two')
-  })
+    expect(buffer.contents).to.have.length(2);
+    expect(buffer.contents[0].text).to.equal("one one one");
+    expect(buffer.contents[1].text).to.equal("two two two");
+  });
 
-  it('removes lines by index', function () {
-    buffer.append(makeLines(['zero', 'one', 'two', 'three']))
+  it("removes lines by index", function() {
+    buffer.append(makeLines(["zero", "one", "two", "three"]));
 
-    buffer.remove(2)
-
-    expect(buffer.contents.map(each => each.text)).to.deep.equal([
-      'zero', 'one', 'three'
-    ])
-  })
-
-  it('replaces lines by index', function () {
-    buffer.append(makeLines(['zero', 'one', 'two', 'three']))
-
-    buffer.replace(1, makeLines(['new']))
+    buffer.remove(2);
 
     expect(buffer.contents.map(each => each.text)).to.deep.equal([
-      'zero', 'new', 'two', 'three'
-    ])
-  })
+      "zero",
+      "one",
+      "three",
+    ]);
+  });
 
-  it('clears all lines', function () {
-    buffer.append(makeLines(['zero', 'one', 'two', 'three']))
+  it("replaces lines by index", function() {
+    buffer.append(makeLines(["zero", "one", "two", "three"]));
 
-    buffer.clear()
+    buffer.replace(1, makeLines(["new"]));
 
-    expect(buffer.contents).to.have.length(0)
-  })
+    expect(buffer.contents.map(each => each.text)).to.deep.equal([
+      "zero",
+      "new",
+      "two",
+      "three",
+    ]);
+  });
 
-  it('returns and clears lines', function () {
-    buffer.append(makeLines(['zero', 'one', 'two', 'three']))
+  it("clears all lines", function() {
+    buffer.append(makeLines(["zero", "one", "two", "three"]));
 
-    const committed = buffer.commit()
+    buffer.clear();
 
-    expect(buffer.contents).to.have.length(0)
+    expect(buffer.contents).to.have.length(0);
+  });
+
+  it("returns and clears lines", function() {
+    buffer.append(makeLines(["zero", "one", "two", "three"]));
+
+    const committed = buffer.commit();
+
+    expect(buffer.contents).to.have.length(0);
     expect(committed.map(each => each.text)).to.deep.equal([
-      'zero', 'one', 'two', 'three'
-    ])
-  })
+      "zero",
+      "one",
+      "two",
+      "three",
+    ]);
+  });
 
-  describe('show', function () {
-    it('reports an empty buffer', function () {
-      expect(buffer.contents).to.have.length(0)
-      expect(buffer.show()).to.equal('Your buffer is currently empty.')
-    })
+  describe("show", function() {
+    it("reports an empty buffer", function() {
+      expect(buffer.contents).to.have.length(0);
+      expect(buffer.show()).to.equal("Your buffer is currently empty.");
+    });
 
-    it('shows current lines', function () {
-      buffer.append(makeLines(['zero', 'one', 'two', 'three']))
+    it("shows current lines", function() {
+      buffer.append(makeLines(["zero", "one", "two", "three"]));
       expect(buffer.show()).to.equal(
-        '_(0)_ me: zero\n' +
-        '_(1)_ me: one\n' +
-        '_(2)_ me: two\n' +
-        '_(3)_ me: three'
-      )
-    })
-  })
+        "_(0)_ me: zero\n" +
+          "_(1)_ me: one\n" +
+          "_(2)_ me: two\n" +
+          "_(3)_ me: three"
+      );
+    });
+  });
 
-  describe('persistance', function () {
-    it('restores contents', function () {
-      const buffer0a = Buffer.forUser(room.robot, 'U0')
-      const buffer1a = Buffer.forUser(room.robot, 'U1')
+  describe("persistance", function() {
+    it("restores contents", function() {
+      const buffer0a = Buffer.forUser(room.robot, "U0");
+      const buffer1a = Buffer.forUser(room.robot, "U1");
 
-      buffer0a.append(makeLines(['0', '1', '2', '3', '4']))
-      buffer1a.append(makeLines(['5', '4', '3']))
+      buffer0a.append(makeLines(["0", "1", "2", "3", "4"]));
+      buffer1a.append(makeLines(["5", "4", "3"]));
 
-      Buffer.clear()
+      Buffer.clear();
 
-      const buffer0b = Buffer.forUser(room.robot, 'U0')
-      const buffer1b = Buffer.forUser(room.robot, 'U1')
+      const buffer0b = Buffer.forUser(room.robot, "U0");
+      const buffer1b = Buffer.forUser(room.robot, "U1");
 
       expect(buffer0b.contents.map(each => each.text)).to.deep.equal([
-        '0', '1', '2', '3', '4'
-      ])
+        "0",
+        "1",
+        "2",
+        "3",
+        "4",
+      ]);
       expect(buffer1b.contents.map(each => each.text)).to.deep.equal([
-        '5', '4', '3'
-      ])
-    })
-  })
-})
+        "5",
+        "4",
+        "3",
+      ]);
+    });
+  });
+});

--- a/test/models/cache.test.js
+++ b/test/models/cache.test.js
@@ -1,99 +1,109 @@
-const Helper = require('hubot-test-helper')
-const helper = new Helper([])
+const Helper = require("hubot-test-helper");
+const helper = new Helper([]);
 
-const Cache = require('../../scripts/models/cache')
+const Cache = require("../../scripts/models/cache");
 
-describe('Cache', function () {
-  let room
+describe("Cache", function() {
+  let room;
 
-  beforeEach(function () {
-    room = helper.createRoom({ httpd: false })
-  })
+  beforeEach(function() {
+    room = helper.createRoom({httpd: false});
+  });
 
-  afterEach(function () {
-    room.destroy()
-    Cache.clear()
-  })
+  afterEach(function() {
+    room.destroy();
+    Cache.clear();
+  });
 
-  describe('append', function () {
-    it('stores a new line', function () {
-      const cache = Cache.forChannel(room.robot, 'C12345678')
+  describe("append", function() {
+    it("stores a new line", function() {
+      const cache = Cache.forChannel(room.robot, "C12345678");
 
-      cache.append({ message: {
-        text: 'the text content',
-        user: { name: 'someone' }
-      } })
+      cache.append({
+        message: {
+          text: "the text content",
+          user: {name: "someone"},
+        },
+      });
 
-      expect(cache.lines).to.have.length(1)
+      expect(cache.lines).to.have.length(1);
 
-      const line = cache.lines[0]
-      expect(line.speaker).to.equal('someone')
-      expect(line.text).to.equal('the text content')
-      expect(line.timestamp).to.exist
-    })
+      const line = cache.lines[0];
+      expect(line.speaker).to.equal("someone");
+      expect(line.text).to.equal("the text content");
+      expect(line.timestamp).to.exist;
+    });
 
-    it('splits multi-line messages', function () {
-      const cache = Cache.forChannel(room.robot, 'C12345678')
+    it("splits multi-line messages", function() {
+      const cache = Cache.forChannel(room.robot, "C12345678");
 
-      cache.append({ message: {
-        text: 'multi-line\nmessage',
-        user: { name: 'someone' }
-      } })
+      cache.append({
+        message: {
+          text: "multi-line\nmessage",
+          user: {name: "someone"},
+        },
+      });
 
-      expect(cache.lines).to.have.length(2)
+      expect(cache.lines).to.have.length(2);
 
-      const line0 = cache.lines[0]
-      expect(line0.speaker).to.equal('someone')
-      expect(line0.text).to.equal('message')
-      expect(line0.timestamp).to.exist
+      const line0 = cache.lines[0];
+      expect(line0.speaker).to.equal("someone");
+      expect(line0.text).to.equal("message");
+      expect(line0.timestamp).to.exist;
 
-      const line1 = cache.lines[1]
-      expect(line1.speaker).to.equal('someone')
-      expect(line1.text).to.equal('multi-line')
-      expect(line1.timestamp).to.exist
-    })
+      const line1 = cache.lines[1];
+      expect(line1.speaker).to.equal("someone");
+      expect(line1.text).to.equal("multi-line");
+      expect(line1.timestamp).to.exist;
+    });
 
-    it('only stores the most recent lines', function () {
-      const cache = Cache.forChannel(room.robot, 'C12345678')
+    it("only stores the most recent lines", function() {
+      const cache = Cache.forChannel(room.robot, "C12345678");
 
       for (let i = 0; i < Cache.MAX_SIZE + 100; i++) {
-        cache.append({ message: {
-          text: `message #${i}`,
-          user: { name: 'someone' }
-        } })
+        cache.append({
+          message: {
+            text: `message #${i}`,
+            user: {name: "someone"},
+          },
+        });
       }
 
-      expect(cache.lines).to.have.length(Cache.MAX_SIZE)
-      expect(cache.lines[0].text).to.equal(`message #${Cache.MAX_SIZE + 99}`)
-    })
-  })
+      expect(cache.lines).to.have.length(Cache.MAX_SIZE);
+      expect(cache.lines[0].text).to.equal(`message #${Cache.MAX_SIZE + 99}`);
+    });
+  });
 
-  describe('serialization', function () {
-    it('serializes and restores state from the brain', function () {
-      const cache0a = Cache.forChannel(room.robot, 'C0')
-      const cache1a = Cache.forChannel(room.robot, 'C1')
+  describe("serialization", function() {
+    it("serializes and restores state from the brain", function() {
+      const cache0a = Cache.forChannel(room.robot, "C0");
+      const cache1a = Cache.forChannel(room.robot, "C1");
 
       for (let i = 0; i < 5; i++) {
-        cache0a.append({ message: {
-          text: 'in room C0',
-          user: { name: 'someone' }
-        } })
+        cache0a.append({
+          message: {
+            text: "in room C0",
+            user: {name: "someone"},
+          },
+        });
       }
 
       for (let j = 0; j < 3; j++) {
-        cache1a.append({ message: {
-          text: 'in room C1',
-          user: { name: 'someone' }
-        } })
+        cache1a.append({
+          message: {
+            text: "in room C1",
+            user: {name: "someone"},
+          },
+        });
       }
 
-      Cache.clear()
+      Cache.clear();
 
-      const cache0b = Cache.forChannel(room.robot, 'C0')
-      const cache1b = Cache.forChannel(room.robot, 'C1')
+      const cache0b = Cache.forChannel(room.robot, "C0");
+      const cache1b = Cache.forChannel(room.robot, "C1");
 
-      expect(cache0b.lines).to.have.length(5)
-      expect(cache1b.lines).to.have.length(3)
-    })
-  })
-})
+      expect(cache0b.lines).to.have.length(5);
+      expect(cache1b.lines).to.have.length(3);
+    });
+  });
+});

--- a/test/models/emoji.test.js
+++ b/test/models/emoji.test.js
@@ -1,104 +1,117 @@
-const { emojiCacheFor } = require('../../scripts/models/emoji')
+const {emojiCacheFor} = require("../../scripts/models/emoji");
 
-describe('EmojiCache', function () {
-  let bot
+describe("EmojiCache", function() {
+  let bot;
 
-  beforeEach(function () {
-    bot = new BotContext()
-  })
+  beforeEach(function() {
+    bot = new BotContext();
+  });
 
-  afterEach(function () {
-    bot.destroy()
-  })
+  afterEach(function() {
+    bot.destroy();
+  });
 
-  function stubEndpoint () {
-    const list = sinon.stub()
+  function stubEndpoint() {
+    const list = sinon.stub();
     bot.getRobot().adapter.client = {
-      web: { emoji: { list } }
-    }
-    return list
+      web: {emoji: {list}},
+    };
+    return list;
   }
 
-  describe('when empty', function () {
-    it('sends a request to the Slack API', async function () {
-      const api = stubEndpoint().returns(Promise.resolve({
-        ok: true,
+  describe("when empty", function() {
+    it("sends a request to the Slack API", async function() {
+      const api = stubEndpoint().returns(
+        Promise.resolve({
+          ok: true,
+          emoji: {
+            squirrel: "https://media0.giphy.com/media/SztNh2RqJmXVC/giphy.gif",
+          },
+        })
+      );
+
+      await emojiCacheFor(bot.getRobot()).get("squirrel");
+      expect(api.called).to.be.true;
+    });
+
+    it("retrieves a custom emoji URL", async function() {
+      stubEndpoint().returns(
+        Promise.resolve({
+          ok: true,
+          emoji: {
+            squirrel: "https://media0.giphy.com/media/SztNh2RqJmXVC/giphy.gif",
+          },
+        })
+      );
+
+      const url = await emojiCacheFor(bot.getRobot()).get("squirrel");
+      expect(url).to.equal(
+        "https://media0.giphy.com/media/SztNh2RqJmXVC/giphy.gif"
+      );
+    });
+
+    it("is a no-op when the Slack adapter is not present", async function() {
+      const result = await emojiCacheFor(bot.getRobot()).get("something");
+      expect(result).to.be.null;
+    });
+  });
+
+  describe("when populated", function() {
+    beforeEach(function() {
+      bot.store("slack:emoji", {
         emoji: {
-          squirrel: 'https://media0.giphy.com/media/SztNh2RqJmXVC/giphy.gif'
-        }
-      }))
-
-      await emojiCacheFor(bot.getRobot()).get('squirrel')
-      expect(api.called).to.be.true
-    })
-
-    it('retrieves a custom emoji URL', async function () {
-      stubEndpoint().returns(Promise.resolve({
-        ok: true,
-        emoji: {
-          squirrel: 'https://media0.giphy.com/media/SztNh2RqJmXVC/giphy.gif'
-        }
-      }))
-
-      const url = await emojiCacheFor(bot.getRobot()).get('squirrel')
-      expect(url).to.equal('https://media0.giphy.com/media/SztNh2RqJmXVC/giphy.gif')
-    })
-
-    it('is a no-op when the Slack adapter is not present', async function () {
-      const result = await emojiCacheFor(bot.getRobot()).get('something')
-      expect(result).to.be.null
-    })
-  })
-
-  describe('when populated', function () {
-    beforeEach(function () {
-      bot.store('slack:emoji', {
-        emoji: {
-          sausage: 'https://media0.giphy.com/media/SztNh2RqJmXVC/giphy.gif',
-          sassage: 'alias:sausage'
+          sausage: "https://media0.giphy.com/media/SztNh2RqJmXVC/giphy.gif",
+          sassage: "alias:sausage",
         },
-        age: Date.now()
-      })
-    })
+        age: Date.now(),
+      });
+    });
 
-    it('retrieves a custom emoji URL', async function () {
-      const result = await emojiCacheFor(bot.getRobot()).get('sausage')
-      expect(result).to.equal('https://media0.giphy.com/media/SztNh2RqJmXVC/giphy.gif')
-    })
+    it("retrieves a custom emoji URL", async function() {
+      const result = await emojiCacheFor(bot.getRobot()).get("sausage");
+      expect(result).to.equal(
+        "https://media0.giphy.com/media/SztNh2RqJmXVC/giphy.gif"
+      );
+    });
 
-    it('returns null for unknown or non-custom emoji', async function () {
-      const result = await emojiCacheFor(bot.getRobot()).get('no')
-      expect(result).to.be.null
-    })
-  })
+    it("returns null for unknown or non-custom emoji", async function() {
+      const result = await emojiCacheFor(bot.getRobot()).get("no");
+      expect(result).to.be.null;
+    });
+  });
 
-  describe('when expired', function () {
-    let api
+  describe("when expired", function() {
+    let api;
 
-    beforeEach(function () {
-      bot.store('slack:emoji', {
+    beforeEach(function() {
+      bot.store("slack:emoji", {
         emoji: {
-          sausage: 'https://media0.giphy.com/media/SztNh2RqJmXVC/giphy.gif'
+          sausage: "https://media0.giphy.com/media/SztNh2RqJmXVC/giphy.gif",
         },
-        age: Date.now() - 2 * 60 * 60 * 1000
-      })
+        age: Date.now() - 2 * 60 * 60 * 1000,
+      });
 
-      api = stubEndpoint().returns(Promise.resolve({
-        ok: true,
-        emoji: {
-          sausage: 'https://user-images.githubusercontent.com/13645/35175029-ce6be492-fd3f-11e7-9dba-ea3ffc6982c4.png'
-        }
-      }))
-    })
+      api = stubEndpoint().returns(
+        Promise.resolve({
+          ok: true,
+          emoji: {
+            sausage:
+              "https://user-images.githubusercontent.com/13645/35175029-ce6be492-fd3f-11e7-9dba-ea3ffc6982c4.png",
+          },
+        })
+      );
+    });
 
-    it('triggers a new request to the Slack API', async function () {
-      await emojiCacheFor(bot.getRobot()).get('sausage')
-      expect(api.called).to.be.true
-    })
+    it("triggers a new request to the Slack API", async function() {
+      await emojiCacheFor(bot.getRobot()).get("sausage");
+      expect(api.called).to.be.true;
+    });
 
-    it('does not return new data yet', async function () {
-      const url = await emojiCacheFor(bot.getRobot()).get('sausage')
-      expect(url).to.equal('https://media0.giphy.com/media/SztNh2RqJmXVC/giphy.gif')
-    })
-  })
-})
+    it("does not return new data yet", async function() {
+      const url = await emojiCacheFor(bot.getRobot()).get("sausage");
+      expect(url).to.equal(
+        "https://media0.giphy.com/media/SztNh2RqJmXVC/giphy.gif"
+      );
+    });
+  });
+});

--- a/test/models/pattern.test.js
+++ b/test/models/pattern.test.js
@@ -1,137 +1,153 @@
-const Helper = require('hubot-test-helper')
-const helper = new Helper([])
+const Helper = require("hubot-test-helper");
+const helper = new Helper([]);
 
-const Cache = require('../../scripts/models/cache')
-const Pattern = require('../../scripts/models/pattern')
+const Cache = require("../../scripts/models/cache");
+const Pattern = require("../../scripts/models/pattern");
 
-describe('Pattern', function () {
-  describe('parses', function () {
-    it('exact "-delimited patterns', function () {
-      const parsed = Pattern.parse('"this is one pattern"')
-      expect(parsed).to.have.length(1)
-      expect(parsed[0].source).to.equal('this is one pattern')
-    })
+describe("Pattern", function() {
+  describe("parses", function() {
+    it('exact "-delimited patterns', function() {
+      const parsed = Pattern.parse('"this is one pattern"');
+      expect(parsed).to.have.length(1);
+      expect(parsed[0].source).to.equal("this is one pattern");
+    });
 
-    it('exact \'-delimited patterns', function () {
-      const parsed = Pattern.parse("'also a single pattern'")
-      expect(parsed).to.have.length(1)
-      expect(parsed[0].source).to.equal('also a single pattern')
-    })
+    it("exact '-delimited patterns", function() {
+      const parsed = Pattern.parse("'also a single pattern'");
+      expect(parsed).to.have.length(1);
+      expect(parsed[0].source).to.equal("also a single pattern");
+    });
 
-    it('allows \\ escaping', function () {
-      const parsed = Pattern.parse('"still a \\" single pattern" "and \\\\ this"')
-      expect(parsed).to.have.length(2)
-      expect(parsed[0].source).to.equal('still a " single pattern')
-      expect(parsed[1].source).to.equal('and \\ this')
-    })
+    it("allows \\ escaping", function() {
+      const parsed = Pattern.parse(
+        '"still a \\" single pattern" "and \\\\ this"'
+      );
+      expect(parsed).to.have.length(2);
+      expect(parsed[0].source).to.equal('still a " single pattern');
+      expect(parsed[1].source).to.equal("and \\ this");
+    });
 
-    it('regexp /-delimited patterns', function () {
-      const parsed = Pattern.parse('/foo\\\\s+bar/')
-      expect(parsed).to.have.length(1)
-      expect(parsed[0].rx.test('foo   bar')).to.be.true
-      expect(parsed[0].rx.test('foo bar')).to.be.true
-      expect(parsed[0].rx.test('nope')).to.be.false
-    })
+    it("regexp /-delimited patterns", function() {
+      const parsed = Pattern.parse("/foo\\\\s+bar/");
+      expect(parsed).to.have.length(1);
+      expect(parsed[0].rx.test("foo   bar")).to.be.true;
+      expect(parsed[0].rx.test("foo bar")).to.be.true;
+      expect(parsed[0].rx.test("nope")).to.be.false;
+    });
 
-    it('between patterns', function () {
-      const parsed = Pattern.parse('"start" ... /end/')
-      expect(parsed).to.have.length(1)
-      expect(parsed[0].start.source).to.equal('start')
-      expect(parsed[0].end.rx.test('end')).to.be.true
-    })
+    it("between patterns", function() {
+      const parsed = Pattern.parse('"start" ... /end/');
+      expect(parsed).to.have.length(1);
+      expect(parsed[0].start.source).to.equal("start");
+      expect(parsed[0].end.rx.test("end")).to.be.true;
+    });
 
-    it('without a space between patterns', function () {
-      const parsed = Pattern.parse('"start"...\'end\'')
-      expect(parsed).to.have.length(1)
-      expect(parsed[0].start.source).to.equal('start')
-      expect(parsed[0].end.source).to.equal('end')
-    })
+    it("without a space between patterns", function() {
+      const parsed = Pattern.parse("\"start\"...'end'");
+      expect(parsed).to.have.length(1);
+      expect(parsed[0].start.source).to.equal("start");
+      expect(parsed[0].end.source).to.equal("end");
+    });
 
-    it('fails on unexpected characters outside of delimiters', function () {
-      expect(() => Pattern.parse('oops')).to.throw(/You need to quote patterns/)
-    })
+    it("fails on unexpected characters outside of delimiters", function() {
+      expect(() => Pattern.parse("oops")).to.throw(
+        /You need to quote patterns/
+      );
+    });
 
-    it('fails on an unterminated delimiter', function () {
-      expect(() => Pattern.parse('"hold that thought')).to.throw(/Unbalanced/)
-    })
+    it("fails on an unterminated delimiter", function() {
+      expect(() => Pattern.parse('"hold that thought')).to.throw(/Unbalanced/);
+    });
 
-    it('fails on a between pattern with no start', function () {
-      expect(() => Pattern.parse('... "huh"')).to.throw(/without a start/)
-    })
+    it("fails on a between pattern with no start", function() {
+      expect(() => Pattern.parse('... "huh"')).to.throw(/without a start/);
+    });
 
-    it('fails on a between pattern with no end', function () {
-      expect(() => Pattern.parse('"what" ...')).to.throw(/without an end/)
-    })
+    it("fails on a between pattern with no end", function() {
+      expect(() => Pattern.parse('"what" ...')).to.throw(/without an end/);
+    });
 
-    it('disallows nested between patterns', function () {
-      expect(() => Pattern.parse('"er" ... ... "?"')).to.throw(/cannot be/)
-    })
+    it("disallows nested between patterns", function() {
+      expect(() => Pattern.parse('"er" ... ... "?"')).to.throw(/cannot be/);
+    });
 
-    it('returns all matched patterns in sequence', function () {
-      const parsed = Pattern.parse('"one" "two three" /four/ ... /five/ "last"')
-      expect(parsed).to.have.length(4)
-      expect(parsed[0].source).to.equal('one')
-      expect(parsed[1].source).to.equal('two three')
-      expect(parsed[2].start.rx.test('four')).to.be.true
-      expect(parsed[2].end.rx.test('five')).to.be.true
-      expect(parsed[3].source).to.equal('last')
-    })
-  })
+    it("returns all matched patterns in sequence", function() {
+      const parsed = Pattern.parse(
+        '"one" "two three" /four/ ... /five/ "last"'
+      );
+      expect(parsed).to.have.length(4);
+      expect(parsed[0].source).to.equal("one");
+      expect(parsed[1].source).to.equal("two three");
+      expect(parsed[2].start.rx.test("four")).to.be.true;
+      expect(parsed[2].end.rx.test("five")).to.be.true;
+      expect(parsed[3].source).to.equal("last");
+    });
+  });
 
-  describe('matches', function () {
-    let room, cache
+  describe("matches", function() {
+    let room, cache;
 
-    beforeEach(async function () {
-      room = helper.createRoom({ httpd: false })
+    beforeEach(async function() {
+      room = helper.createRoom({httpd: false});
 
-      cache = Cache.forChannel(room.robot, 'C12345678')
+      cache = Cache.forChannel(room.robot, "C12345678");
       const lines = [
-        'aaa 000', 'bbb 000', 'ccc 000', 'ddd 000', 'eee 000',
-        'aaa 111', 'bbb 111', 'ccc 111', 'ddd 111', 'eee 111'
-      ]
+        "aaa 000",
+        "bbb 000",
+        "ccc 000",
+        "ddd 000",
+        "eee 000",
+        "aaa 111",
+        "bbb 111",
+        "ccc 111",
+        "ddd 111",
+        "eee 111",
+      ];
       for (const line of lines) {
-        cache.append({ message: {
-          text: line,
-          user: { name: 'someone' }
-        } })
+        cache.append({
+          message: {
+            text: line,
+            user: {name: "someone"},
+          },
+        });
       }
-    })
+    });
 
-    afterEach(function () {
-      room.destroy()
-      Cache.clear()
-    })
+    afterEach(function() {
+      room.destroy();
+      Cache.clear();
+    });
 
-    it('the most recent exact', function () {
-      const pattern = Pattern.parse('"ccc"')[0]
-      const matches = pattern.matchesIn(cache)
+    it("the most recent exact", function() {
+      const pattern = Pattern.parse('"ccc"')[0];
+      const matches = pattern.matchesIn(cache);
 
-      expect(matches).to.have.length(1)
-      expect(matches[0].text).to.equal('ccc 111')
-    })
+      expect(matches).to.have.length(1);
+      expect(matches[0].text).to.equal("ccc 111");
+    });
 
-    it('the most recent regular expression match', function () {
-      const pattern = Pattern.parse('/b+/')[0]
-      const matches = pattern.matchesIn(cache)
+    it("the most recent regular expression match", function() {
+      const pattern = Pattern.parse("/b+/")[0];
+      const matches = pattern.matchesIn(cache);
 
-      expect(matches).to.have.length(1)
-      expect(matches[0].text).to.equal('bbb 111')
-    })
+      expect(matches).to.have.length(1);
+      expect(matches[0].text).to.equal("bbb 111");
+    });
 
-    it('captures between patterns', function () {
-      const pattern = Pattern.parse('"111" ... "ccc"')[0]
-      const matches = pattern.matchesIn(cache)
+    it("captures between patterns", function() {
+      const pattern = Pattern.parse('"111" ... "ccc"')[0];
+      const matches = pattern.matchesIn(cache);
 
-      expect(matches).to.have.length(2)
-      expect(matches[0].text).to.equal('bbb 111')
-      expect(matches[1].text).to.equal('ccc 111')
-    })
+      expect(matches).to.have.length(2);
+      expect(matches[0].text).to.equal("bbb 111");
+      expect(matches[1].text).to.equal("ccc 111");
+    });
 
-    it('returns an empty array if no matches are found', function () {
-      const pattern = Pattern.parse('"nope"')[0]
-      const matches = pattern.matchesIn(cache)
+    it("returns an empty array if no matches are found", function() {
+      const pattern = Pattern.parse('"nope"')[0];
+      const matches = pattern.matchesIn(cache);
 
-      expect(matches).to.have.length(0)
-    })
-  })
-})
+      expect(matches).to.have.length(0);
+    });
+  });
+});

--- a/test/quotes/add.test.js
+++ b/test/quotes/add.test.js
@@ -1,392 +1,433 @@
-const moment = require('moment-timezone')
+const moment = require("moment-timezone");
 
-const { createDocumentSet } = require('../../scripts/documentset')
-const { OnlyMe } = require('./roles')
-const Line = require('../../scripts/models/line')
+const {createDocumentSet} = require("../../scripts/documentset");
+const {OnlyMe} = require("./roles");
+const Line = require("../../scripts/models/line");
 
-describe('DocumentSet add', function () {
-  let bot, time, documentSet
+describe("DocumentSet add", function() {
+  let bot, time, documentSet;
 
-  beforeEach(function () {
-    bot = new BotContext()
-    time = new TimeContext()
-  })
+  beforeEach(function() {
+    bot = new BotContext();
+    time = new TimeContext();
+  });
 
-  afterEach(function () {
-    bot.destroy()
-    time.destroy()
+  afterEach(function() {
+    bot.destroy();
+    time.destroy();
     if (documentSet) {
-      return documentSet.destroy()
+      return documentSet.destroy();
     }
-  })
+  });
 
-  it('creates "slackapp blarf:"', async function () {
-    usesDatabase(this)
+  it('creates "slackapp blarf:"', async function() {
+    usesDatabase(this);
 
-    documentSet = createDocumentSet(bot.getRobot(), 'blarf', { add: true })
+    documentSet = createDocumentSet(bot.getRobot(), "blarf", {add: true});
 
-    const blarfToAdd = 'person-one [2:00 PM] \n' +
-      'foo bar baz\n' +
-      '\n' +
-      '[2:01]  \n' +
-      'aaa bbb ccc\n'
+    const blarfToAdd =
+      "person-one [2:00 PM] \n" +
+      "foo bar baz\n" +
+      "\n" +
+      "[2:01]  \n" +
+      "aaa bbb ccc\n";
 
-    const expectedBlarf = '[2:00 PM 9 Apr 2017] person-one: foo bar baz\n' +
-      '[2:01 PM 9 Apr 2017] person-one: aaa bbb ccc'
+    const expectedBlarf =
+      "[2:00 PM 9 Apr 2017] person-one: foo bar baz\n" +
+      "[2:01 PM 9 Apr 2017] person-one: aaa bbb ccc";
 
-    await documentSet.whenConnected()
-    await bot.say('me', `@hubot slackapp blarf: ${blarfToAdd}`)
-    await bot.waitForResponse('1 blarf loaded.')
+    await documentSet.whenConnected();
+    await bot.say("me", `@hubot slackapp blarf: ${blarfToAdd}`);
+    await bot.waitForResponse("1 blarf loaded.");
 
-    const doc = await documentSet.randomMatching({}, '"foo bar baz"')
-    expect(doc.getBody()).to.equal(expectedBlarf)
-  })
+    const doc = await documentSet.randomMatching({}, '"foo bar baz"');
+    expect(doc.getBody()).to.equal(expectedBlarf);
+  });
 
-  it('extracts "speaker" attributes from slackapp input', async function () {
-    documentSet = createDocumentSet(bot.getRobot(), 'blarf', { add: true })
+  it('extracts "speaker" attributes from slackapp input', async function() {
+    documentSet = createDocumentSet(bot.getRobot(), "blarf", {add: true});
 
-    const blarfToAdd = 'person-one [2:00 PM] \n' +
-      'one one one' +
-      '\n' +
-      '[2:01]  \n' +
-      'two two two\n' +
-      '\n' +
-      'person-two [9:09 AM] \n' +
-      'three three three'
+    const blarfToAdd =
+      "person-one [2:00 PM] \n" +
+      "one one one" +
+      "\n" +
+      "[2:01]  \n" +
+      "two two two\n" +
+      "\n" +
+      "person-two [9:09 AM] \n" +
+      "three three three";
 
-    const expectedBlarf = '[2:00 PM 9 Apr 2017] person-one: one one one\n' +
-      '[2:01 PM 9 Apr 2017] person-one: two two two\n' +
-      '[9:09 AM 9 Apr 2017] person-two: three three three'
+    const expectedBlarf =
+      "[2:00 PM 9 Apr 2017] person-one: one one one\n" +
+      "[2:01 PM 9 Apr 2017] person-one: two two two\n" +
+      "[9:09 AM 9 Apr 2017] person-two: three three three";
 
-    await documentSet.whenConnected()
-    await bot.say('me', `@hubot slackapp blarf: ${blarfToAdd}`)
-    await bot.waitForResponse('1 blarf loaded.')
+    await documentSet.whenConnected();
+    await bot.say("me", `@hubot slackapp blarf: ${blarfToAdd}`);
+    await bot.waitForResponse("1 blarf loaded.");
 
-    const doc = await documentSet.randomMatching({ speaker: ['person-one', 'person-two'] }, '')
-    expect(doc.getBody()).to.equal(expectedBlarf)
-  })
+    const doc = await documentSet.randomMatching(
+      {speaker: ["person-one", "person-two"]},
+      ""
+    );
+    expect(doc.getBody()).to.equal(expectedBlarf);
+  });
 
-  it('extracts "mention" attributes from slackapp input', async function () {
-    usesDatabase(this)
+  it('extracts "mention" attributes from slackapp input', async function() {
+    usesDatabase(this);
 
-    documentSet = createDocumentSet(bot.getRobot(), 'blarf', { add: true })
+    documentSet = createDocumentSet(bot.getRobot(), "blarf", {add: true});
 
-    const blarfToAdd = 'person-one [2:00 PM] \n' +
-      'one one one' +
-      '\n' +
-      '[2:01]  \n' +
-      '@person-two: two two two\n' +
-      '\n' +
-      'person-two [9:09 AM] \n' +
-      'three three three person-three'
+    const blarfToAdd =
+      "person-one [2:00 PM] \n" +
+      "one one one" +
+      "\n" +
+      "[2:01]  \n" +
+      "@person-two: two two two\n" +
+      "\n" +
+      "person-two [9:09 AM] \n" +
+      "three three three person-three";
 
-    const expectedBlarf = '[2:00 PM 9 Apr 2017] person-one: one one one\n' +
-      '[2:01 PM 9 Apr 2017] person-one: @person-two: two two two\n' +
-      '[9:09 AM 9 Apr 2017] person-two: three three three person-three'
+    const expectedBlarf =
+      "[2:00 PM 9 Apr 2017] person-one: one one one\n" +
+      "[2:01 PM 9 Apr 2017] person-one: @person-two: two two two\n" +
+      "[9:09 AM 9 Apr 2017] person-two: three three three person-three";
 
-    bot.createUser('1', 'person-one')
-    bot.createUser('2', 'person-two')
-    bot.createUser('3', 'person-three')
-    bot.createUser('4', 'person-four')
+    bot.createUser("1", "person-one");
+    bot.createUser("2", "person-two");
+    bot.createUser("3", "person-three");
+    bot.createUser("4", "person-four");
 
-    await documentSet.whenConnected()
-    await bot.say('me', `@hubot slackapp blarf: ${blarfToAdd}`)
-    await bot.waitForResponse('1 blarf loaded.')
+    await documentSet.whenConnected();
+    await bot.say("me", `@hubot slackapp blarf: ${blarfToAdd}`);
+    await bot.waitForResponse("1 blarf loaded.");
 
-    const doc = await documentSet.randomMatching({ mention: ['person-two', 'person-three'] }, '')
-    expect(doc.getBody()).to.equal(expectedBlarf)
-  })
+    const doc = await documentSet.randomMatching(
+      {mention: ["person-two", "person-three"]},
+      ""
+    );
+    expect(doc.getBody()).to.equal(expectedBlarf);
+  });
 
-  it('removes "new messages" from "slackapp blarf:"', async function () {
-    usesDatabase(this)
+  it('removes "new messages" from "slackapp blarf:"', async function() {
+    usesDatabase(this);
 
-    documentSet = createDocumentSet(bot.getRobot(), 'blarf', { add: true })
+    documentSet = createDocumentSet(bot.getRobot(), "blarf", {add: true});
 
-    const blarfToAdd = 'person-one [2:00 PM] \n' +
-      'one one one' +
-      '\n' +
-      '[2:01]  \n' +
-      'two two two\n' +
-      '\n' +
-      'new messages\n' +
-      '\n' +
-      'person-two [9:09 AM] \n' +
-      'three three three'
+    const blarfToAdd =
+      "person-one [2:00 PM] \n" +
+      "one one one" +
+      "\n" +
+      "[2:01]  \n" +
+      "two two two\n" +
+      "\n" +
+      "new messages\n" +
+      "\n" +
+      "person-two [9:09 AM] \n" +
+      "three three three";
 
-    const expectedBlarf = '[2:00 PM 9 Apr 2017] person-one: one one one\n' +
-      '[2:01 PM 9 Apr 2017] person-one: two two two\n' +
-      '[9:09 AM 9 Apr 2017] person-two: three three three'
+    const expectedBlarf =
+      "[2:00 PM 9 Apr 2017] person-one: one one one\n" +
+      "[2:01 PM 9 Apr 2017] person-one: two two two\n" +
+      "[9:09 AM 9 Apr 2017] person-two: three three three";
 
-    await documentSet.whenConnected()
-    await bot.say('me', `@hubot slackapp blarf: ${blarfToAdd}`)
-    await bot.waitForResponse('1 blarf loaded.')
+    await documentSet.whenConnected();
+    await bot.say("me", `@hubot slackapp blarf: ${blarfToAdd}`);
+    await bot.waitForResponse("1 blarf loaded.");
 
-    const doc = await documentSet.randomMatching([], '"two two two"')
-    expect(doc.getBody()).to.equal(expectedBlarf)
-  })
+    const doc = await documentSet.randomMatching([], '"two two two"');
+    expect(doc.getBody()).to.equal(expectedBlarf);
+  });
 
-  it('removes "edited" from "slackapp blarf:"', async function () {
-    usesDatabase(this)
-    documentSet = createDocumentSet(bot.getRobot(), 'blarf', { add: true })
+  it('removes "edited" from "slackapp blarf:"', async function() {
+    usesDatabase(this);
+    documentSet = createDocumentSet(bot.getRobot(), "blarf", {add: true});
 
-    const blarfToAdd = 'person-one [8:53 PM] \n' +
-      'one one one' +
-      '\n' +
-      '[8:53]  \n' +
-      'whatever (edited)\n' +
-      '\n' +
-      '[8:53]  \n' +
-      '\n' +
-      'three three three'
+    const blarfToAdd =
+      "person-one [8:53 PM] \n" +
+      "one one one" +
+      "\n" +
+      "[8:53]  \n" +
+      "whatever (edited)\n" +
+      "\n" +
+      "[8:53]  \n" +
+      "\n" +
+      "three three three";
 
-    const expectedBlarf = '[8:53 PM 9 Apr 2017] person-one: one one one\n' +
-      '[8:53 PM 9 Apr 2017] person-one: whatever\n' +
-      '[8:53 PM 9 Apr 2017] person-one: three three three'
+    const expectedBlarf =
+      "[8:53 PM 9 Apr 2017] person-one: one one one\n" +
+      "[8:53 PM 9 Apr 2017] person-one: whatever\n" +
+      "[8:53 PM 9 Apr 2017] person-one: three three three";
 
-    await documentSet.whenConnected()
-    await bot.say('me', `@hubot slackapp blarf: ${blarfToAdd}`)
-    await bot.waitForResponse('1 blarf loaded.')
+    await documentSet.whenConnected();
+    await bot.say("me", `@hubot slackapp blarf: ${blarfToAdd}`);
+    await bot.waitForResponse("1 blarf loaded.");
 
-    const doc = await documentSet.randomMatching([], 'whatever')
-    expect(doc.getBody()).to.equal(expectedBlarf)
-  })
+    const doc = await documentSet.randomMatching([], "whatever");
+    expect(doc.getBody()).to.equal(expectedBlarf);
+  });
 
-  it('removes APP from integration output in "slackapp blarf:"', async function () {
-    usesDatabase(this)
-    documentSet = createDocumentSet(bot.getRobot(), 'blarf', { add: true })
+  it('removes APP from integration output in "slackapp blarf:"', async function() {
+    usesDatabase(this);
+    documentSet = createDocumentSet(bot.getRobot(), "blarf", {add: true});
 
-    const blarfToAdd = 'me [1:10 PM]\n' +
-      '!quote\n' +
-      '\n' +
-      'pushbotAPP [1:10 PM]\n' +
-      'some response\n' +
-      '\n' +
-      'someone-else [1:20 PM]\n' +
-      'more text' +
-      '\n'
+    const blarfToAdd =
+      "me [1:10 PM]\n" +
+      "!quote\n" +
+      "\n" +
+      "pushbotAPP [1:10 PM]\n" +
+      "some response\n" +
+      "\n" +
+      "someone-else [1:20 PM]\n" +
+      "more text" +
+      "\n";
 
-    const expectedBlarf = '[1:10 PM 9 Apr 2017] me: !quote\n' +
-      '[1:10 PM 9 Apr 2017] pushbot: some response\n' +
-      '[1:20 PM 9 Apr 2017] someone-else: more text'
+    const expectedBlarf =
+      "[1:10 PM 9 Apr 2017] me: !quote\n" +
+      "[1:10 PM 9 Apr 2017] pushbot: some response\n" +
+      "[1:20 PM 9 Apr 2017] someone-else: more text";
 
-    await documentSet.whenConnected()
-    await bot.say('me', `@hubot slackapp blarf: ${blarfToAdd}`)
-    await bot.waitForResponse('1 blarf loaded.')
+    await documentSet.whenConnected();
+    await bot.say("me", `@hubot slackapp blarf: ${blarfToAdd}`);
+    await bot.waitForResponse("1 blarf loaded.");
 
-    const doc = await documentSet.randomMatching([], 'response')
-    expect(doc.getBody()).to.equal(expectedBlarf)
-  })
+    const doc = await documentSet.randomMatching([], "response");
+    expect(doc.getBody()).to.equal(expectedBlarf);
+  });
 
-  it('rejects malformed "slackapp blarf:" input', async function () {
-    usesDatabase(this)
-    documentSet = createDocumentSet(bot.getRobot(), 'blarf', { add: true })
+  it('rejects malformed "slackapp blarf:" input', async function() {
+    usesDatabase(this);
+    documentSet = createDocumentSet(bot.getRobot(), "blarf", {add: true});
 
-    const malformedBlarf = '!quote\n' +
-      '\n' +
-      'person [1:10 PM]\n' +
-      'some response\n'
+    const malformedBlarf =
+      "!quote\n" + "\n" + "person [1:10 PM]\n" + "some response\n";
 
-    await documentSet.whenConnected()
-    await bot.say('me', `@hubot slackapp blarf: ${malformedBlarf}`)
-    await bot.waitForResponse(/sadtrombone\.com/)
-  })
+    await documentSet.whenConnected();
+    await bot.say("me", `@hubot slackapp blarf: ${malformedBlarf}`);
+    await bot.waitForResponse(/sadtrombone\.com/);
+  });
 
-  it('creates "verbatim blarf:"', async function () {
-    usesDatabase(this)
-    documentSet = createDocumentSet(bot.getRobot(), 'blarf', { add: true })
+  it('creates "verbatim blarf:"', async function() {
+    usesDatabase(this);
+    documentSet = createDocumentSet(bot.getRobot(), "blarf", {add: true});
 
-    const verbatimBlarf = 'look ma\n' +
-      'no formatting'
+    const verbatimBlarf = "look ma\n" + "no formatting";
 
-    await documentSet.whenConnected()
-    await bot.say('me', `@hubot verbatim blarf: ${verbatimBlarf}`)
-    await bot.waitForResponse('1 blarf loaded.')
+    await documentSet.whenConnected();
+    await bot.say("me", `@hubot verbatim blarf: ${verbatimBlarf}`);
+    await bot.waitForResponse("1 blarf loaded.");
 
-    const doc = await documentSet.randomMatching([], 'formatting')
-    expect(doc.getBody()).to.equal(verbatimBlarf)
-  })
+    const doc = await documentSet.randomMatching([], "formatting");
+    expect(doc.getBody()).to.equal(verbatimBlarf);
+  });
 
-  it('extracts "mention" attributes from verbatim input', async function () {
-    usesDatabase(this)
-    documentSet = createDocumentSet(bot.getRobot(), 'blarf', { add: true })
+  it('extracts "mention" attributes from verbatim input', async function() {
+    usesDatabase(this);
+    documentSet = createDocumentSet(bot.getRobot(), "blarf", {add: true});
 
-    const verbatimBlarf = 'something about person-four\n' +
-      'and @person-two with an @\n' +
-      'andperson-onebutnotreally'
+    const verbatimBlarf =
+      "something about person-four\n" +
+      "and @person-two with an @\n" +
+      "andperson-onebutnotreally";
 
-    bot.createUser('1', 'person-one')
-    bot.createUser('2', 'person-two')
-    bot.createUser('3', 'person-three')
-    bot.createUser('4', 'person-four')
+    bot.createUser("1", "person-one");
+    bot.createUser("2", "person-two");
+    bot.createUser("3", "person-three");
+    bot.createUser("4", "person-four");
 
-    await documentSet.whenConnected()
-    await bot.say('me', `@hubot verbatim blarf: ${verbatimBlarf}`)
-    await bot.waitForResponse('1 blarf loaded.')
+    await documentSet.whenConnected();
+    await bot.say("me", `@hubot verbatim blarf: ${verbatimBlarf}`);
+    await bot.waitForResponse("1 blarf loaded.");
 
-    const doc = await documentSet.randomMatching({ mention: ['person-two', 'person-four'] }, '')
-    expect(doc.getBody()).to.equal(verbatimBlarf)
-  })
+    const doc = await documentSet.randomMatching(
+      {mention: ["person-two", "person-four"]},
+      ""
+    );
+    expect(doc.getBody()).to.equal(verbatimBlarf);
+  });
 
-  it('creates "buffer blarf"', async function () {
-    usesDatabase(this)
-    documentSet = createDocumentSet(bot.getRobot(), 'blarf', { add: true })
+  it('creates "buffer blarf"', async function() {
+    usesDatabase(this);
+    documentSet = createDocumentSet(bot.getRobot(), "blarf", {add: true});
 
-    bot.load('buffer.js')
+    bot.load("buffer.js");
 
-    const ts = hhmm => moment.tz(`2017-04-01 ${hhmm}`, 'YYYY-MM-DD HH:mm', 'America/New_York')
-    const buffer = bot.getRobot().bufferForUserId('me')
+    const ts = hhmm =>
+      moment.tz(`2017-04-01 ${hhmm}`, "YYYY-MM-DD HH:mm", "America/New_York");
+    const buffer = bot.getRobot().bufferForUserId("me");
     buffer.append([
-      new Line(ts('9:30'), 'person-one', 'one one one'),
-      new Line(ts('9:31'), 'person-two', 'two two two'),
-      new Line(ts('9:32'), 'person-three', 'three three three')
-    ])
+      new Line(ts("9:30"), "person-one", "one one one"),
+      new Line(ts("9:31"), "person-two", "two two two"),
+      new Line(ts("9:32"), "person-three", "three three three"),
+    ]);
 
-    const expectedBlarf = '[9:30 AM 1 Apr 2017] person-one: one one one\n' +
-      '[9:31 AM 1 Apr 2017] person-two: two two two\n' +
-      '[9:32 AM 1 Apr 2017] person-three: three three three'
+    const expectedBlarf =
+      "[9:30 AM 1 Apr 2017] person-one: one one one\n" +
+      "[9:31 AM 1 Apr 2017] person-two: two two two\n" +
+      "[9:32 AM 1 Apr 2017] person-three: three three three";
 
-    await documentSet.whenConnected()
-    await bot.say('me', '@hubot buffer blarf')
-    await bot.waitForResponse(/1 blarf loaded\./)
+    await documentSet.whenConnected();
+    await bot.say("me", "@hubot buffer blarf");
+    await bot.waitForResponse(/1 blarf loaded\./);
 
-    const doc = await documentSet.randomMatching([], 'two')
-    expect(doc.getBody()).to.equal(expectedBlarf)
-  })
+    const doc = await documentSet.randomMatching([], "two");
+    expect(doc.getBody()).to.equal(expectedBlarf);
+  });
 
-  it('extracts "speaker" attributes from buffer input', async function () {
-    usesDatabase(this)
-    documentSet = createDocumentSet(bot.getRobot(), 'blarf', { add: true })
+  it('extracts "speaker" attributes from buffer input', async function() {
+    usesDatabase(this);
+    documentSet = createDocumentSet(bot.getRobot(), "blarf", {add: true});
 
-    bot.load('buffer.js')
+    bot.load("buffer.js");
 
-    const ts = hhmm => moment.tz(`2017-04-01 ${hhmm}`, 'YYYY-MM-DD HH:mm', 'America/New_York')
-    const buffer = bot.getRobot().bufferForUserId('me')
+    const ts = hhmm =>
+      moment.tz(`2017-04-01 ${hhmm}`, "YYYY-MM-DD HH:mm", "America/New_York");
+    const buffer = bot.getRobot().bufferForUserId("me");
     buffer.append([
-      new Line(ts('10:00'), 'person-one', 'person-four: one one one'),
-      new Line(ts('10:01'), 'person-two', 'two two two'),
-      new Line(ts('10:01'), 'person-one', 'three three three @person-one')
-    ])
+      new Line(ts("10:00"), "person-one", "person-four: one one one"),
+      new Line(ts("10:01"), "person-two", "two two two"),
+      new Line(ts("10:01"), "person-one", "three three three @person-one"),
+    ]);
 
-    const expectedBlarf = '[10:00 AM 1 Apr 2017] person-one: person-four: one one one\n' +
-      '[10:01 AM 1 Apr 2017] person-two: two two two\n' +
-      '[10:01 AM 1 Apr 2017] person-one: three three three @person-one'
+    const expectedBlarf =
+      "[10:00 AM 1 Apr 2017] person-one: person-four: one one one\n" +
+      "[10:01 AM 1 Apr 2017] person-two: two two two\n" +
+      "[10:01 AM 1 Apr 2017] person-one: three three three @person-one";
 
-    await documentSet.whenConnected()
-    await bot.say('me', '@hubot buffer blarf')
-    await bot.waitForResponse(/1 blarf loaded\./)
+    await documentSet.whenConnected();
+    await bot.say("me", "@hubot buffer blarf");
+    await bot.waitForResponse(/1 blarf loaded\./);
 
-    const doc = await documentSet.randomMatching({ speaker: ['person-one', 'person-two'] }, '')
-    expect(doc.getBody()).to.equal(expectedBlarf)
-  })
+    const doc = await documentSet.randomMatching(
+      {speaker: ["person-one", "person-two"]},
+      ""
+    );
+    expect(doc.getBody()).to.equal(expectedBlarf);
+  });
 
-  it('extracts "mention" attributes from buffer input', async function () {
-    usesDatabase(this)
-    documentSet = createDocumentSet(bot.getRobot(), 'blarf', { add: true })
+  it('extracts "mention" attributes from buffer input', async function() {
+    usesDatabase(this);
+    documentSet = createDocumentSet(bot.getRobot(), "blarf", {add: true});
 
-    bot.load('buffer.js')
+    bot.load("buffer.js");
 
-    const ts = hhmm => moment.tz(`2017-04-01 ${hhmm}`, 'YYYY-MM-DD HH:mm', 'America/New_York')
-    const buffer = bot.getRobot().bufferForUserId('me')
+    const ts = hhmm =>
+      moment.tz(`2017-04-01 ${hhmm}`, "YYYY-MM-DD HH:mm", "America/New_York");
+    const buffer = bot.getRobot().bufferForUserId("me");
     buffer.append([
-      new Line(ts('10:00'), 'person-one', 'one one one @person-two'),
-      new Line(ts('10:01'), 'person-two', 'two two two'),
-      new Line(ts('10:01'), 'person-one', 'three three three person-three')
-    ])
+      new Line(ts("10:00"), "person-one", "one one one @person-two"),
+      new Line(ts("10:01"), "person-two", "two two two"),
+      new Line(ts("10:01"), "person-one", "three three three person-three"),
+    ]);
 
-    const expectedBlarf = '[10:00 AM 1 Apr 2017] person-one: one one one @person-two\n' +
-      '[10:01 AM 1 Apr 2017] person-two: two two two\n' +
-      '[10:01 AM 1 Apr 2017] person-one: three three three person-three'
+    const expectedBlarf =
+      "[10:00 AM 1 Apr 2017] person-one: one one one @person-two\n" +
+      "[10:01 AM 1 Apr 2017] person-two: two two two\n" +
+      "[10:01 AM 1 Apr 2017] person-one: three three three person-three";
 
-    bot.createUser('1', 'person-one')
-    bot.createUser('2', 'person-two')
-    bot.createUser('3', 'person-three')
-    bot.createUser('4', 'person-four')
+    bot.createUser("1", "person-one");
+    bot.createUser("2", "person-two");
+    bot.createUser("3", "person-three");
+    bot.createUser("4", "person-four");
 
-    await documentSet.whenConnected()
-    await bot.say('me', '@hubot buffer blarf')
-    await bot.waitForResponse(/1 blarf loaded\./)
+    await documentSet.whenConnected();
+    await bot.say("me", "@hubot buffer blarf");
+    await bot.waitForResponse(/1 blarf loaded\./);
 
-    const doc = await documentSet.randomMatching({ mention: ['person-two', 'person-three'] }, '')
-    expect(doc.getBody()).to.equal(expectedBlarf)
-  })
+    const doc = await documentSet.randomMatching(
+      {mention: ["person-two", "person-three"]},
+      ""
+    );
+    expect(doc.getBody()).to.equal(expectedBlarf);
+  });
 
-  it('can be configured with a document formatter', async function () {
-    usesDatabase(this)
-    documentSet = createDocumentSet(bot.getRobot(), 'blarf', {
+  it("can be configured with a document formatter", async function() {
+    usesDatabase(this);
+    documentSet = createDocumentSet(bot.getRobot(), "blarf", {
       add: {
         formatter: (lines, speakers, mentions) => {
           return {
-            body: lines.map(line => `[${line.speaker}] ${line.text}`).join(', '),
+            body: lines
+              .map(line => `[${line.speaker}] ${line.text}`)
+              .join(", "),
             speakers,
-            mentions
-          }
-        }
-      }
-    })
+            mentions,
+          };
+        },
+      },
+    });
 
-    const source = 'person-one [2:00 PM] \n' +
-      'one one one' +
-      '\n' +
-      '[2:01]  \n' +
-      'two two two\n' +
-      '\n' +
-      'person-two [9:09 AM] \n' +
-      'three three three'
+    const source =
+      "person-one [2:00 PM] \n" +
+      "one one one" +
+      "\n" +
+      "[2:01]  \n" +
+      "two two two\n" +
+      "\n" +
+      "person-two [9:09 AM] \n" +
+      "three three three";
 
-    const expected = '[person-one] one one one, [person-one] two two two, [person-two] three three three'
+    const expected =
+      "[person-one] one one one, [person-one] two two two, [person-two] three three three";
 
-    await bot.say('me', `@hubot slackapp blarf: ${source}`)
-    await bot.waitForResponse('1 blarf loaded.')
+    await bot.say("me", `@hubot slackapp blarf: ${source}`);
+    await bot.waitForResponse("1 blarf loaded.");
 
-    const doc = await documentSet.randomMatching({ speaker: ['person-one', 'person-two'] }, '')
-    expect(doc.getBody()).to.equal(expected)
-  })
+    const doc = await documentSet.randomMatching(
+      {speaker: ["person-one", "person-two"]},
+      ""
+    );
+    expect(doc.getBody()).to.equal(expected);
+  });
 
-  it('validates a required role', async function () {
-    documentSet = createDocumentSet(bot.getRobot(), 'blarf',
-      { add: { role: OnlyMe } }
-    )
+  it("validates a required role", async function() {
+    documentSet = createDocumentSet(bot.getRobot(), "blarf", {
+      add: {role: OnlyMe},
+    });
 
-    await documentSet.whenConnected()
-    await bot.say('you', '@hubot verbatim blarf: nope')
-    await bot.waitForResponse('@you NOPE')
+    await documentSet.whenConnected();
+    await bot.say("you", "@hubot verbatim blarf: nope");
+    await bot.waitForResponse("@you NOPE");
 
-    expect(await documentSet.countMatching({}, '')).to.equal(0)
-  })
+    expect(await documentSet.countMatching({}, "")).to.equal(0);
+  });
 
-  it('generates default help text', async function () {
-    usesDatabase(this)
-    await bot.loadHelp()
+  it("generates default help text", async function() {
+    usesDatabase(this);
+    await bot.loadHelp();
 
-    documentSet = createDocumentSet(bot.getRobot(), 'blarf', { add: true })
-    await bot.say('me', '@hubot help blarf')
-    await bot.waitForResponse(/buffer blarf/)
+    documentSet = createDocumentSet(bot.getRobot(), "blarf", {add: true});
+    await bot.say("me", "@hubot help blarf");
+    await bot.waitForResponse(/buffer blarf/);
 
-    const messages = bot.helpLines()
+    const messages = bot.helpLines();
 
-    expect(messages).to.include("hubot slackapp blarf: <source> - Parse a blarf from the Slack app's paste format.")
-    expect(messages).to.include('hubot verbatim blarf: <source> - Insert a blarf exactly as given.')
-    expect(messages).to.include('hubot buffer blarf - Insert a blarf from the current contents of your buffer.')
-  })
+    expect(messages).to.include(
+      "hubot slackapp blarf: <source> - Parse a blarf from the Slack app's paste format."
+    );
+    expect(messages).to.include(
+      "hubot verbatim blarf: <source> - Insert a blarf exactly as given."
+    );
+    expect(messages).to.include(
+      "hubot buffer blarf - Insert a blarf from the current contents of your buffer."
+    );
+  });
 
-  it('accepts custom help text', async function () {
-    usesDatabase(this)
-    await bot.loadHelp()
+  it("accepts custom help text", async function() {
+    usesDatabase(this);
+    await bot.loadHelp();
 
-    documentSet = createDocumentSet(bot.getRobot(), 'blarf', {
+    documentSet = createDocumentSet(bot.getRobot(), "blarf", {
       add: {
-        helpText: [
-          'hubot blarf 1 - First line',
-          'hubot blarf 2 - Second line'
-        ]
-      }
-    })
+        helpText: ["hubot blarf 1 - First line", "hubot blarf 2 - Second line"],
+      },
+    });
 
-    await bot.say('me', '@hubot help blarf')
-    await bot.waitForResponse(/blarf/)
+    await bot.say("me", "@hubot help blarf");
+    await bot.waitForResponse(/blarf/);
 
-    const messages = bot.helpLines()
-    expect(messages).to.include('hubot blarf 1 - First line')
-    expect(messages).to.include('hubot blarf 2 - Second line')
-  })
-})
+    const messages = bot.helpLines();
+    expect(messages).to.include("hubot blarf 1 - First line");
+    expect(messages).to.include("hubot blarf 2 - Second line");
+  });
+});

--- a/test/quotes/all.test.js
+++ b/test/quotes/all.test.js
@@ -1,61 +1,65 @@
-const { createDocumentSet } = require('../../scripts/documentset')
+const {createDocumentSet} = require("../../scripts/documentset");
 
-describe('DocumentSet all', function () {
-  let bot, documentSet
+describe("DocumentSet all", function() {
+  let bot, documentSet;
 
-  beforeEach(function () {
-    bot = new BotContext()
-  })
+  beforeEach(function() {
+    bot = new BotContext();
+  });
 
-  afterEach(function () {
-    bot.destroy()
+  afterEach(function() {
+    bot.destroy();
     if (documentSet) {
-      return documentSet.destroy()
+      return documentSet.destroy();
     }
-  })
+  });
 
-  async function populate (commandOpts = true, docs = [], parallel = true) {
-    documentSet = createDocumentSet(bot.getRobot(), 'blarf', {
-      all: commandOpts
-    })
+  async function populate(commandOpts = true, docs = [], parallel = true) {
+    documentSet = createDocumentSet(bot.getRobot(), "blarf", {
+      all: commandOpts,
+    });
 
     const args = docs.map(doc => {
-      let body = ''
-      const attributes = []
+      let body = "";
+      const attributes = [];
       if (doc.body && doc.subject) {
-        body = doc.body
-        attributes.push({ kind: 'subject', value: doc.subject })
+        body = doc.body;
+        attributes.push({kind: "subject", value: doc.subject});
       } else {
-        body = doc
+        body = doc;
       }
-      return ['me', body, attributes]
-    })
+      return ["me", body, attributes];
+    });
 
     if (parallel) {
-      await Promise.all(args.map(arg => documentSet.add(...arg)))
+      await Promise.all(args.map(arg => documentSet.add(...arg)));
     } else {
       for (const arg of args) {
-        await documentSet.add(...arg)
+        await documentSet.add(...arg);
       }
     }
   }
 
-  it('returns all known documents', async function () {
-    await populate(true, ['one', 'two', 'three'], false)
+  it("returns all known documents", async function() {
+    await populate(true, ["one", "two", "three"], false);
 
-    await bot.say('me', '@hubot allblarfs')
-    await bot.waitForResponse('one, two, three')
-  })
+    await bot.say("me", "@hubot allblarfs");
+    await bot.waitForResponse("one, two, three");
+  });
 
-  it('returns all documents associated with a user', async function () {
-    await populate({ userOriented: true }, [
-      { body: '111', subject: 'you' },
-      { body: '222', subject: 'you' },
-      { body: '000', subject: 'nope' },
-      { body: '333', subject: 'you' }
-    ], false)
+  it("returns all documents associated with a user", async function() {
+    await populate(
+      {userOriented: true},
+      [
+        {body: "111", subject: "you"},
+        {body: "222", subject: "you"},
+        {body: "000", subject: "nope"},
+        {body: "333", subject: "you"},
+      ],
+      false
+    );
 
-    await bot.say('me', '@hubot allblarfs @you')
-    await bot.waitForResponse('111, 222, 333')
-  })
-})
+    await bot.say("me", "@hubot allblarfs @you");
+    await bot.waitForResponse("111, 222, 333");
+  });
+});

--- a/test/quotes/attrqueries.test.js
+++ b/test/quotes/attrqueries.test.js
@@ -1,142 +1,145 @@
-const { createDocumentSet } = require('../../scripts/documentset')
-const { OnlyMe } = require('./roles')
+const {createDocumentSet} = require("../../scripts/documentset");
+const {OnlyMe} = require("./roles");
 
-function generateAttributeQueryTests (commandName, attributeName) {
-  return function () {
-    let bot, documentSet
+function generateAttributeQueryTests(commandName, attributeName) {
+  return function() {
+    let bot, documentSet;
 
-    beforeEach(function () {
-      bot = new BotContext()
-    })
+    beforeEach(function() {
+      bot = new BotContext();
+    });
 
-    afterEach(function () {
-      bot.destroy()
+    afterEach(function() {
+      bot.destroy();
       if (documentSet) {
-        return documentSet.destroy()
+        return documentSet.destroy();
       }
-    })
+    });
 
-    function populate (commandOpts = true, docs = []) {
-      documentSet = createDocumentSet(bot.getRobot(), 'blarf', {
-        [commandName]: commandOpts
-      })
+    function populate(commandOpts = true, docs = []) {
+      documentSet = createDocumentSet(bot.getRobot(), "blarf", {
+        [commandName]: commandOpts,
+      });
 
       return Promise.all(
         docs.map(doc => {
-          const attributes = doc.attrs.map(value => ({ kind: attributeName, value }))
-          return documentSet.add('me', doc.body, attributes)
+          const attributes = doc.attrs.map(value => ({
+            kind: attributeName,
+            value,
+          }));
+          return documentSet.add("me", doc.body, attributes);
         })
-      )
+      );
     }
 
-    it(`returns a random document ${commandName} the requested speaker`, async function () {
-      usesDatabase(this)
+    it(`returns a random document ${commandName} the requested speaker`, async function() {
+      usesDatabase(this);
       await populate(true, [
-        { body: 'yes 1', attrs: ['aaa', 'bbb'] },
-        { body: 'no 1', attrs: ['bbb'] },
-        { body: 'yes 2', attrs: ['zzz', 'aaa'] },
-        { body: 'no 2', attrs: ['yyy', 'ccc', 'bbb'] },
-        { body: 'no 3', attrs: ['qqq'] }
-      ])
+        {body: "yes 1", attrs: ["aaa", "bbb"]},
+        {body: "no 1", attrs: ["bbb"]},
+        {body: "yes 2", attrs: ["zzz", "aaa"]},
+        {body: "no 2", attrs: ["yyy", "ccc", "bbb"]},
+        {body: "no 3", attrs: ["qqq"]},
+      ]);
 
-      await bot.say('me', `@hubot blarf${commandName} aaa`)
-      await bot.waitForResponse(/^(yes 1|yes 2)$/)
-    })
+      await bot.say("me", `@hubot blarf${commandName} aaa`);
+      await bot.waitForResponse(/^(yes 1|yes 2)$/);
+    });
 
-    it(`returns a random document with the requested ${attributeName} matching a query`, async function () {
-      usesDatabase(this)
+    it(`returns a random document with the requested ${attributeName} matching a query`, async function() {
+      usesDatabase(this);
       await populate(true, [
-        { body: 'no 1', attrs: ['aaa', 'bbb'] },
-        { body: 'no 2', attrs: ['bbb'] },
-        { body: 'yes 1', attrs: ['zzz', 'aaa'] },
-        { body: 'no 3', attrs: ['yyy', 'ccc', 'bbb'] },
-        { body: 'no 4', attrs: ['aaa'] }
-      ])
+        {body: "no 1", attrs: ["aaa", "bbb"]},
+        {body: "no 2", attrs: ["bbb"]},
+        {body: "yes 1", attrs: ["zzz", "aaa"]},
+        {body: "no 3", attrs: ["yyy", "ccc", "bbb"]},
+        {body: "no 4", attrs: ["aaa"]},
+      ]);
 
-      await bot.say('me', `@hubot blarf${commandName} @aaa yes`)
-      await bot.waitForResponse('yes 1')
-    })
+      await bot.say("me", `@hubot blarf${commandName} @aaa yes`);
+      await bot.waitForResponse("yes 1");
+    });
 
-    it(`returns a random document with multiple ${attributeName}s`, async function () {
-      usesDatabase(this)
+    it(`returns a random document with multiple ${attributeName}s`, async function() {
+      usesDatabase(this);
       await populate(true, [
-        { body: 'no 1', attrs: ['aaa', 'bbb'] },
-        { body: 'no 2', attrs: ['bbb'] },
-        { body: 'no 3', attrs: ['zzz', 'aaa'] },
-        { body: 'yes 1', attrs: ['yyy', 'ccc', 'bbb'] },
-        { body: 'no 4', attrs: ['aaa'] }
-      ])
+        {body: "no 1", attrs: ["aaa", "bbb"]},
+        {body: "no 2", attrs: ["bbb"]},
+        {body: "no 3", attrs: ["zzz", "aaa"]},
+        {body: "yes 1", attrs: ["yyy", "ccc", "bbb"]},
+        {body: "no 4", attrs: ["aaa"]},
+      ]);
 
-      await bot.say('me', `@hubot blarf${commandName} @ccc+yyy`)
-      await bot.waitForResponse('yes 1')
-    })
+      await bot.say("me", `@hubot blarf${commandName} @ccc+yyy`);
+      await bot.waitForResponse("yes 1");
+    });
 
-    it(`returns a random document with multiple ${attributeName}s matching a query`, async function () {
-      usesDatabase(this)
+    it(`returns a random document with multiple ${attributeName}s matching a query`, async function() {
+      usesDatabase(this);
       await populate(true, [
-        { body: 'no 1', attrs: ['aaa', 'bbb'] },
-        { body: 'no 2', attrs: ['bbb'] },
-        { body: 'no 3', attrs: ['zzz', 'aaa'] },
-        { body: 'no 4', attrs: ['yyy', 'ccc', 'bbb'] },
-        { body: 'yes 1', attrs: ['aaa', 'bbb'] }
-      ])
+        {body: "no 1", attrs: ["aaa", "bbb"]},
+        {body: "no 2", attrs: ["bbb"]},
+        {body: "no 3", attrs: ["zzz", "aaa"]},
+        {body: "no 4", attrs: ["yyy", "ccc", "bbb"]},
+        {body: "yes 1", attrs: ["aaa", "bbb"]},
+      ]);
 
-      await bot.say('me', `@hubot blarf${commandName} @aaa+bbb yes`)
-      await bot.waitForResponse('yes 1')
-    })
+      await bot.say("me", `@hubot blarf${commandName} @aaa+bbb yes`);
+      await bot.waitForResponse("yes 1");
+    });
 
-    it("permits access based on the caller's role", async function () {
-      usesDatabase(this)
-      await populate({ role: OnlyMe }, [
-        { body: 'yes 1', attrs: ['aaa', 'bbb'] }
-      ])
+    it("permits access based on the caller's role", async function() {
+      usesDatabase(this);
+      await populate({role: OnlyMe}, [{body: "yes 1", attrs: ["aaa", "bbb"]}]);
 
-      await bot.say('me', `@hubot blarf${commandName} bbb`)
-      await bot.waitForResponse('yes 1')
-    })
+      await bot.say("me", `@hubot blarf${commandName} bbb`);
+      await bot.waitForResponse("yes 1");
+    });
 
-    it("prohibits access based on the caller's role", async function () {
-      usesDatabase(this)
-      await populate({ role: OnlyMe }, [
-        { body: 'yes 1', attrs: ['aaa', 'bbb'] }
-      ])
+    it("prohibits access based on the caller's role", async function() {
+      usesDatabase(this);
+      await populate({role: OnlyMe}, [{body: "yes 1", attrs: ["aaa", "bbb"]}]);
 
-      await bot.say('you', `@hubot blarf${commandName} bbb`)
-      await bot.waitForResponse('@you NOPE')
-    })
+      await bot.say("you", `@hubot blarf${commandName} bbb`);
+      await bot.waitForResponse("@you NOPE");
+    });
 
-    it('generates default help text', async function () {
-      await bot.loadHelp()
-      documentSet = createDocumentSet(bot.getRobot(), 'blarf', { [commandName]: true })
+    it("generates default help text", async function() {
+      await bot.loadHelp();
+      documentSet = createDocumentSet(bot.getRobot(), "blarf", {
+        [commandName]: true,
+      });
 
-      await bot.say('me', `@hubot help blarf${commandName}`)
-      await bot.waitForResponse(/blarf/)
+      await bot.say("me", `@hubot help blarf${commandName}`);
+      await bot.waitForResponse(/blarf/);
 
-      const messages = bot.helpLines().filter(line => line.startsWith(`hubot blarf${commandName}`))
-      expect(messages).to.have.length(3)
-    })
+      const messages = bot
+        .helpLines()
+        .filter(line => line.startsWith(`hubot blarf${commandName}`));
+      expect(messages).to.have.length(3);
+    });
 
-    it('accepts custom help text', async function () {
-      await bot.loadHelp()
-      documentSet = createDocumentSet(bot.getRobot(), 'blarf', {
+    it("accepts custom help text", async function() {
+      await bot.loadHelp();
+      documentSet = createDocumentSet(bot.getRobot(), "blarf", {
         [commandName]: {
           helpText: [
             `hubot blarf${commandName} 1 - line one`,
-            `hubot blarf${commandName} 2 - line two`
-          ]
-        }
-      })
+            `hubot blarf${commandName} 2 - line two`,
+          ],
+        },
+      });
 
-      await bot.say('me', `@hubot help blarf${commandName}`)
-      await bot.waitForResponse(/blarf/)
+      await bot.say("me", `@hubot help blarf${commandName}`);
+      await bot.waitForResponse(/blarf/);
 
-      const messages = bot.helpLines()
-      expect(messages).to.include(`hubot blarf${commandName} 1 - line one`)
-      expect(messages).to.include(`hubot blarf${commandName} 2 - line two`)
-    })
-  }
-};
+      const messages = bot.helpLines();
+      expect(messages).to.include(`hubot blarf${commandName} 1 - line one`);
+      expect(messages).to.include(`hubot blarf${commandName} 2 - line two`);
+    });
+  };
+}
 
-describe('DocumentSet by', generateAttributeQueryTests('by', 'speaker'))
+describe("DocumentSet by", generateAttributeQueryTests("by", "speaker"));
 
-describe('DocumentSet about', generateAttributeQueryTests('about', 'mention'))
+describe("DocumentSet about", generateAttributeQueryTests("about", "mention"));

--- a/test/quotes/count.test.js
+++ b/test/quotes/count.test.js
@@ -1,109 +1,128 @@
-const { createDocumentSet } = require('../../scripts/documentset')
-const { OnlyMe } = require('./roles')
+const {createDocumentSet} = require("../../scripts/documentset");
+const {OnlyMe} = require("./roles");
 
-describe('DocumentSet count', function () {
-  let bot, documentSet
+describe("DocumentSet count", function() {
+  let bot, documentSet;
 
-  beforeEach(function () {
-    bot = new BotContext()
-  })
+  beforeEach(function() {
+    bot = new BotContext();
+  });
 
-  afterEach(function () {
-    bot.destroy()
+  afterEach(function() {
+    bot.destroy();
     if (documentSet) {
-      return documentSet.destroy()
+      return documentSet.destroy();
     }
-  })
+  });
 
-  function populate (commandOpts = true, docs = []) {
-    documentSet = createDocumentSet(bot.getRobot(), 'blarf', {
-      count: commandOpts
-    })
+  function populate(commandOpts = true, docs = []) {
+    documentSet = createDocumentSet(bot.getRobot(), "blarf", {
+      count: commandOpts,
+    });
 
-    return Promise.all(
-      docs.map(doc => documentSet.add('me', doc, []))
-    )
+    return Promise.all(docs.map(doc => documentSet.add("me", doc, [])));
   }
 
-  it('counts all documents', async function () {
-    usesDatabase(this)
+  it("counts all documents", async function() {
+    usesDatabase(this);
 
-    await populate(true, ['111', '222', '333', '444', '555'])
-    await bot.say('me', '@hubot blarfcount')
-    await bot.waitForResponse('@me there are 5 blarfs.')
-  })
+    await populate(true, ["111", "222", "333", "444", "555"]);
+    await bot.say("me", "@hubot blarfcount");
+    await bot.waitForResponse("@me there are 5 blarfs.");
+  });
 
-  it('uses a singular noun for single results', async function () {
-    await populate(true, ['111'])
-    await bot.say('me', '@hubot blarfcount')
-    await bot.waitForResponse('@me there is 1 blarf.')
-  })
+  it("uses a singular noun for single results", async function() {
+    await populate(true, ["111"]);
+    await bot.say("me", "@hubot blarfcount");
+    await bot.waitForResponse("@me there is 1 blarf.");
+  });
 
-  it('counts documents matching all query terms', async function () {
-    usesDatabase(this)
+  it("counts documents matching all query terms", async function() {
+    usesDatabase(this);
 
-    await populate(true, ['aaa zzz 1', 'aaa zzz 2', 'aaa bbb 0', 'bbb zzz 0', 'xxx yyy 0'])
-    await bot.say('me', '@hubot blarfcount zzz aaa')
-    await bot.waitForResponse('@me there are 2 blarfs matching `zzz aaa`.')
-  })
+    await populate(true, [
+      "aaa zzz 1",
+      "aaa zzz 2",
+      "aaa bbb 0",
+      "bbb zzz 0",
+      "xxx yyy 0",
+    ]);
+    await bot.say("me", "@hubot blarfcount zzz aaa");
+    await bot.waitForResponse("@me there are 2 blarfs matching `zzz aaa`.");
+  });
 
-  it('counts documents matching quoted query terms', async function () {
-    usesDatabase(this)
+  it("counts documents matching quoted query terms", async function() {
+    usesDatabase(this);
 
-    await populate(true, ['aaa zzz 1', 'aaa zzz 2', 'aaa bbb 0', 'bbb zzz 0', 'xxx yyy 0', 'zzz aaa 0'])
-    await bot.say('me', '@hubot blarfcount "aaa zzz"')
-    await bot.waitForResponse('@me there are 2 blarfs matching `"aaa zzz"`.')
-  })
+    await populate(true, [
+      "aaa zzz 1",
+      "aaa zzz 2",
+      "aaa bbb 0",
+      "bbb zzz 0",
+      "xxx yyy 0",
+      "zzz aaa 0",
+    ]);
+    await bot.say("me", '@hubot blarfcount "aaa zzz"');
+    await bot.waitForResponse('@me there are 2 blarfs matching `"aaa zzz"`.');
+  });
 
-  it('uses a singular noun for single results matching a query', async function () {
-    await populate(true, ['111', '222'])
-    await bot.say('me', '@hubot blarfcount 11')
-    await bot.waitForResponse('@me there is 1 blarf matching `11`.')
-  })
+  it("uses a singular noun for single results matching a query", async function() {
+    await populate(true, ["111", "222"]);
+    await bot.say("me", "@hubot blarfcount 11");
+    await bot.waitForResponse("@me there is 1 blarf matching `11`.");
+  });
 
-  it("permits access based on the caller's role", async function () {
-    usesDatabase(this)
+  it("permits access based on the caller's role", async function() {
+    usesDatabase(this);
 
-    await populate({ role: OnlyMe }, ['aaa zzz 1', 'aaa zzz 2', 'aaa zzz 3', 'bbb zzz 0', 'xxx yyy 0'])
-    await bot.say('me', '@hubot blarfcount aaa zzz')
-    await bot.waitForResponse('@me there are 3 blarfs matching `aaa zzz`.')
-  })
+    await populate({role: OnlyMe}, [
+      "aaa zzz 1",
+      "aaa zzz 2",
+      "aaa zzz 3",
+      "bbb zzz 0",
+      "xxx yyy 0",
+    ]);
+    await bot.say("me", "@hubot blarfcount aaa zzz");
+    await bot.waitForResponse("@me there are 3 blarfs matching `aaa zzz`.");
+  });
 
-  it("prohibits access based on the caller's role", async function () {
-    usesDatabase(this)
+  it("prohibits access based on the caller's role", async function() {
+    usesDatabase(this);
 
-    await populate({ role: OnlyMe }, ['aaa zzz 1', 'aaa zzz 2'])
-    await bot.say('you', '@hubot blarfcount aaa zzz')
-    await bot.waitForResponse('@you NOPE')
-  })
+    await populate({role: OnlyMe}, ["aaa zzz 1", "aaa zzz 2"]);
+    await bot.say("you", "@hubot blarfcount aaa zzz");
+    await bot.waitForResponse("@you NOPE");
+  });
 
-  it('generates default help text', async function () {
-    await bot.loadHelp()
-    documentSet = createDocumentSet(bot.getRobot(), 'blarf', { count: true })
+  it("generates default help text", async function() {
+    await bot.loadHelp();
+    documentSet = createDocumentSet(bot.getRobot(), "blarf", {count: true});
 
-    await bot.say('me', '@hubot help blarfcount')
-    await bot.waitForResponse(/blarfcount/)
+    await bot.say("me", "@hubot help blarfcount");
+    await bot.waitForResponse(/blarfcount/);
 
-    const messages = bot.helpLines()
-    expect(messages).to.include('hubot blarfcount - Total number of blarfs.')
-    expect(messages).to.include('hubot blarfcount <query> - Number of blarfs matching <query>.')
-  })
+    const messages = bot.helpLines();
+    expect(messages).to.include("hubot blarfcount - Total number of blarfs.");
+    expect(messages).to.include(
+      "hubot blarfcount <query> - Number of blarfs matching <query>."
+    );
+  });
 
-  it('accepts custom help text', async function () {
-    await bot.loadHelp()
-    documentSet = createDocumentSet(bot.getRobot(), 'blarf', {
+  it("accepts custom help text", async function() {
+    await bot.loadHelp();
+    documentSet = createDocumentSet(bot.getRobot(), "blarf", {
       count: {
         helpText: [
-          'hubot blarfcount 1 - line one',
-          'hubot blarfcount 2 - line two'
-        ]
-      }
-    })
-    await bot.say('me', '@hubot help blarfcount')
-    await bot.waitForResponse(/blarfcount/)
+          "hubot blarfcount 1 - line one",
+          "hubot blarfcount 2 - line two",
+        ],
+      },
+    });
+    await bot.say("me", "@hubot help blarfcount");
+    await bot.waitForResponse(/blarfcount/);
 
-    const messages = bot.helpLines()
-    expect(messages).to.include('hubot blarfcount 1 - line one')
-    expect(messages).to.include('hubot blarfcount 2 - line two')
-  })
-})
+    const messages = bot.helpLines();
+    expect(messages).to.include("hubot blarfcount 1 - line one");
+    expect(messages).to.include("hubot blarfcount 2 - line two");
+  });
+});

--- a/test/quotes/kov.test.js
+++ b/test/quotes/kov.test.js
@@ -1,90 +1,98 @@
-const { createDocumentSet } = require('../../scripts/documentset')
+const {createDocumentSet} = require("../../scripts/documentset");
 
-describe('DocumentSet markov models', function () {
-  let bot, time, documentSet
+describe("DocumentSet markov models", function() {
+  let bot, time, documentSet;
 
-  beforeEach(async function () {
-    bot = new BotContext()
-    time = new TimeContext()
+  beforeEach(async function() {
+    bot = new BotContext();
+    time = new TimeContext();
 
-    process.env.HUBOT_MARKOV_DEFAULT_MODEL = 'false'
-    process.env.HUBOT_MARKOV_REVERSE_MODEL = 'false'
-    await bot.loadMarkov()
-  })
+    process.env.HUBOT_MARKOV_DEFAULT_MODEL = "false";
+    process.env.HUBOT_MARKOV_REVERSE_MODEL = "false";
+    await bot.loadMarkov();
+  });
 
-  afterEach(async function () {
+  afterEach(async function() {
     await new Promise(resolve => {
       try {
-        bot.getRobot().markov.modelNamed('blarfkov', model => model.destroy(resolve))
-      } catch (e) { resolve() }
-    })
+        bot
+          .getRobot()
+          .markov.modelNamed("blarfkov", model => model.destroy(resolve));
+      } catch (e) {
+        resolve();
+      }
+    });
 
-    bot.destroy()
-    time.destroy()
+    bot.destroy();
+    time.destroy();
     if (documentSet) {
-      return documentSet.destroy()
+      return documentSet.destroy();
     }
-  })
+  });
 
-  it('creates a markov model', async function () {
-    expect(() => bot.getRobot().markov.modelNamed('blarfkov', () => {})).to.throw(/Unrecognized model/)
+  it("creates a markov model", async function() {
+    expect(() =>
+      bot.getRobot().markov.modelNamed("blarfkov", () => {})
+    ).to.throw(/Unrecognized model/);
 
-    documentSet = createDocumentSet(bot.getRobot(), 'blarf', { kov: true })
+    documentSet = createDocumentSet(bot.getRobot(), "blarf", {kov: true});
 
-    bot.getRobot().markov.modelNamed('blarfkov', model => {
-      expect(model).to.not.be.undefined
-    })
-  })
+    bot.getRobot().markov.modelNamed("blarfkov", model => {
+      expect(model).to.not.be.undefined;
+    });
+  });
 
-  it('adds new documents to the model', async function () {
-    documentSet = createDocumentSet(bot.getRobot(), 'blarf', { add: true, kov: true })
+  it("adds new documents to the model", async function() {
+    documentSet = createDocumentSet(bot.getRobot(), "blarf", {
+      add: true,
+      kov: true,
+    });
 
-    const blarfToAdd = 'person-one [2:00 PM] \n' +
-      'foo bar baz\n'
+    const blarfToAdd = "person-one [2:00 PM] \n" + "foo bar baz\n";
 
-    await documentSet.whenConnected()
-    await bot.say('me', `@hubot slackapp blarf: ${blarfToAdd}`)
-    await bot.waitForResponse('1 blarf loaded.')
+    await documentSet.whenConnected();
+    await bot.say("me", `@hubot slackapp blarf: ${blarfToAdd}`);
+    await bot.waitForResponse("1 blarf loaded.");
 
     const output = await new Promise((resolve, reject) => {
-      bot.getRobot().markov.modelNamed('blarfkov', model => {
-        model.generate('', 10, (err, text) => {
-          if (err) return reject(err)
-          resolve(text)
-        })
-      })
-    })
-    expect(output).to.equal('person-one: foo bar baz')
-  })
+      bot.getRobot().markov.modelNamed("blarfkov", model => {
+        model.generate("", 10, (err, text) => {
+          if (err) return reject(err);
+          resolve(text);
+        });
+      });
+    });
+    expect(output).to.equal("person-one: foo bar baz");
+  });
 
-  it('generates text from the model', async function () {
-    documentSet = createDocumentSet(bot.getRobot(), 'blarf', { kov: true })
+  it("generates text from the model", async function() {
+    documentSet = createDocumentSet(bot.getRobot(), "blarf", {kov: true});
 
-    await documentSet.whenConnected()
+    await documentSet.whenConnected();
     await new Promise(resolve => {
-      bot.getRobot().markov.modelNamed('blarfkov', model => {
-        model.learn('aaa bbb ccc', err => {
-          expect(err).to.not.be.ok
-          resolve()
-        })
-      })
-    })
+      bot.getRobot().markov.modelNamed("blarfkov", model => {
+        model.learn("aaa bbb ccc", err => {
+          expect(err).to.not.be.ok;
+          resolve();
+        });
+      });
+    });
 
-    await bot.say('me', '@hubot blarfkov')
-    await bot.waitForResponse('aaa bbb ccc')
-  })
+    await bot.say("me", "@hubot blarfkov");
+    await bot.waitForResponse("aaa bbb ccc");
+  });
 
-  it('re-indexes the model from all documents', async function () {
-    documentSet = createDocumentSet(bot.getRobot(), 'blarf', {})
-    await documentSet.add('me', 'aaa bbb ccc', [])
-    await documentSet.add('me', 'aaa ddd eee', [])
+  it("re-indexes the model from all documents", async function() {
+    documentSet = createDocumentSet(bot.getRobot(), "blarf", {});
+    await documentSet.add("me", "aaa bbb ccc", []);
+    await documentSet.add("me", "aaa ddd eee", []);
 
-    documentSet = createDocumentSet(bot.getRobot(), 'blarf', { kov: true })
-    await documentSet.whenConnected()
-    await bot.say('me', '@hubot reindex blarfkov')
-    await bot.waitForResponse('@me Regenerated markov model from 2 blarfs.')
+    documentSet = createDocumentSet(bot.getRobot(), "blarf", {kov: true});
+    await documentSet.whenConnected();
+    await bot.say("me", "@hubot reindex blarfkov");
+    await bot.waitForResponse("@me Regenerated markov model from 2 blarfs.");
 
-    await bot.say('me', '@hubot blarfkov')
-    await bot.waitForResponse(/^aaa (bbb ccc|ddd eee)$/)
-  })
-})
+    await bot.say("me", "@hubot blarfkov");
+    await bot.waitForResponse(/^aaa (bbb ccc|ddd eee)$/);
+  });
+});

--- a/test/quotes/query.test.js
+++ b/test/quotes/query.test.js
@@ -1,186 +1,218 @@
-const { OnlyMe } = require('./roles')
+const {OnlyMe} = require("./roles");
 
-const { createDocumentSet } = require('../../scripts/documentset')
+const {createDocumentSet} = require("../../scripts/documentset");
 
-describe('DocumentSet query', function () {
-  let bot, documentSet
+describe("DocumentSet query", function() {
+  let bot, documentSet;
 
-  beforeEach(function () {
-    bot = new BotContext()
-  })
+  beforeEach(function() {
+    bot = new BotContext();
+  });
 
-  afterEach(function () {
-    bot.destroy()
+  afterEach(function() {
+    bot.destroy();
     if (documentSet) {
-      return documentSet.destroy()
+      return documentSet.destroy();
     }
-  })
+  });
 
-  function populate (commandOpts = true, docs = []) {
-    documentSet = createDocumentSet(bot.getRobot(), 'blarf', {
-      query: commandOpts
-    })
+  function populate(commandOpts = true, docs = []) {
+    documentSet = createDocumentSet(bot.getRobot(), "blarf", {
+      query: commandOpts,
+    });
 
     return Promise.all(
       docs.map(doc => {
-        let body = ''
-        const attributes = []
+        let body = "";
+        const attributes = [];
         if (doc.body && doc.subject) {
-          body = doc.body
-          attributes.push({ kind: 'subject', value: doc.subject })
+          body = doc.body;
+          attributes.push({kind: "subject", value: doc.subject});
         } else {
-          body = doc
+          body = doc;
         }
-        return documentSet.add('me', body, attributes)
+        return documentSet.add("me", body, attributes);
       })
-    )
+    );
   }
 
-  it('returns a random result', async function () {
-    usesDatabase(this)
+  it("returns a random result", async function() {
+    usesDatabase(this);
 
-    await populate(true, ['one', 'two', 'three'])
-    await bot.say('me', '@hubot blarf')
-    await bot.waitForResponse(/^(one|two|three)$/)
-  })
+    await populate(true, ["one", "two", "three"]);
+    await bot.say("me", "@hubot blarf");
+    await bot.waitForResponse(/^(one|two|three)$/);
+  });
 
-  it('returns a random document containing all terms within a query', async function () {
-    usesDatabase(this)
-
-    await populate(true, [
-      'aaa 111 zzz', 'aaa 222 yyy', 'yyy 333 xxx',
-      'aaa nope', 'aaa nope', 'aaa nope', 'aaa nope', 'aaa nope', 'aaa nope', 'aaa nope', 'aaa nope'
-    ])
-    await bot.say('me', '@hubot blarf aaa 222')
-    await bot.waitForResponse('aaa 222 yyy')
-  })
-
-  it('escapes regular expression metacharacters within query terms', async function () {
-    usesDatabase(this)
+  it("returns a random document containing all terms within a query", async function() {
+    usesDatabase(this);
 
     await populate(true, [
-      'aaa+bbb', 'nope', 'nope', 'nope', 'nope', 'nope', 'nope', 'nope', 'nope', 'nope', 'nope'
-    ])
-    await bot.say('me', '@hubot blarf \\+')
-    await bot.waitForResponse('aaa+bbb')
-  })
+      "aaa 111 zzz",
+      "aaa 222 yyy",
+      "yyy 333 xxx",
+      "aaa nope",
+      "aaa nope",
+      "aaa nope",
+      "aaa nope",
+      "aaa nope",
+      "aaa nope",
+      "aaa nope",
+      "aaa nope",
+    ]);
+    await bot.say("me", "@hubot blarf aaa 222");
+    await bot.waitForResponse("aaa 222 yyy");
+  });
 
-  it('collects words within double quotes as a single term', async function () {
-    usesDatabase(this)
-
-    await populate(true, [
-      'aaa nope bbb', 'aaa nope bbb', 'aaa nope bbb', 'aaa nope bbb', 'aaa nope bbb',
-      'correct aaa bbb'
-    ])
-    await bot.say('me', '@hubot blarf "aaa bbb"')
-    await bot.waitForResponse('correct aaa bbb')
-  })
-
-  it('collects words within single quotes as a single term', async function () {
-    usesDatabase(this)
-
-    await populate(true, [
-      'aaa nope bbb', 'aaa nope bbb', 'aaa nope bbb', 'aaa nope bbb', 'aaa nope bbb',
-      'correct aaa bbb'
-    ])
-    await bot.say('me', "@hubot blarf 'aaa bbb'")
-    await bot.waitForResponse('correct aaa bbb')
-  })
-
-  it('allows terms to contain single and double quotes escaped with a backslash', async function () {
-    usesDatabase(this)
+  it("escapes regular expression metacharacters within query terms", async function() {
+    usesDatabase(this);
 
     await populate(true, [
-      `correct aaa"bbb'ccc`, 'wrong aaabbbccc', 'wrong aaabbbccc', 'wrong aaabbbccc', 'wrong aaabbbccc'
-    ])
-    await bot.say('me', `@hubot blarf aaa\\"bbb\\'ccc`)
-    await bot.waitForResponse(`correct aaa"bbb'ccc`)
-  })
+      "aaa+bbb",
+      "nope",
+      "nope",
+      "nope",
+      "nope",
+      "nope",
+      "nope",
+      "nope",
+      "nope",
+      "nope",
+      "nope",
+    ]);
+    await bot.say("me", "@hubot blarf \\+");
+    await bot.waitForResponse("aaa+bbb");
+  });
 
-  it("permits access based on the caller's role", async function () {
-    usesDatabase(this)
+  it("collects words within double quotes as a single term", async function() {
+    usesDatabase(this);
 
-    await populate({ role: OnlyMe }, ['aaa'])
-    await bot.say('me', '@hubot blarf')
-    await bot.waitForResponse('aaa')
-  })
+    await populate(true, [
+      "aaa nope bbb",
+      "aaa nope bbb",
+      "aaa nope bbb",
+      "aaa nope bbb",
+      "aaa nope bbb",
+      "correct aaa bbb",
+    ]);
+    await bot.say("me", '@hubot blarf "aaa bbb"');
+    await bot.waitForResponse("correct aaa bbb");
+  });
 
-  it("prohibits access based on the caller's role", async function () {
-    usesDatabase(this)
+  it("collects words within single quotes as a single term", async function() {
+    usesDatabase(this);
 
-    await populate({ role: OnlyMe }, ['aaa'])
-    await bot.say('you', '@hubot blarf')
-    await bot.waitForResponse('@you NOPE')
-  })
+    await populate(true, [
+      "aaa nope bbb",
+      "aaa nope bbb",
+      "aaa nope bbb",
+      "aaa nope bbb",
+      "aaa nope bbb",
+      "correct aaa bbb",
+    ]);
+    await bot.say("me", "@hubot blarf 'aaa bbb'");
+    await bot.waitForResponse("correct aaa bbb");
+  });
 
-  it('can be configured to query with a subject user', async function () {
-    usesDatabase(this)
+  it("allows terms to contain single and double quotes escaped with a backslash", async function() {
+    usesDatabase(this);
 
-    await populate({ userOriented: true }, [
-      { body: 'wrong 1', subject: 'me' },
-      { body: 'correct', subject: 'you' },
-      { body: 'wrong 2', subject: 'other' }
-    ])
-    await bot.say('me', '@hubot blarf @you')
-    await bot.waitForResponse('correct')
-  })
+    await populate(true, [
+      `correct aaa"bbb'ccc`,
+      "wrong aaabbbccc",
+      "wrong aaabbbccc",
+      "wrong aaabbbccc",
+      "wrong aaabbbccc",
+    ]);
+    await bot.say("me", `@hubot blarf aaa\\"bbb\\'ccc`);
+    await bot.waitForResponse(`correct aaa"bbb'ccc`);
+  });
 
-  it('can be configured to default to self with no query', async function () {
-    usesDatabase(this)
+  it("permits access based on the caller's role", async function() {
+    usesDatabase(this);
 
-    await populate({ userOriented: true }, [
-      { body: 'wrong 1', subject: 'you' },
-      { body: 'wrong 2', subject: 'you' },
-      { body: 'correct', subject: 'me' },
-      { body: 'wrong 3', subject: 'other' },
-      { body: 'wrong 4', subject: 'person-four' }
-    ])
-    await bot.say('me', '@hubot blarf')
-    await bot.waitForResponse('correct')
-  })
+    await populate({role: OnlyMe}, ["aaa"]);
+    await bot.say("me", "@hubot blarf");
+    await bot.waitForResponse("aaa");
+  });
 
-  it('can be configured to return the latest rather than a random result', async function () {
-    usesDatabase(this)
+  it("prohibits access based on the caller's role", async function() {
+    usesDatabase(this);
 
-    documentSet = createDocumentSet(bot.getRobot(), 'blarf', {
-      query: { userOriented: true, latest: true }
-    })
+    await populate({role: OnlyMe}, ["aaa"]);
+    await bot.say("you", "@hubot blarf");
+    await bot.waitForResponse("@you NOPE");
+  });
+
+  it("can be configured to query with a subject user", async function() {
+    usesDatabase(this);
+
+    await populate({userOriented: true}, [
+      {body: "wrong 1", subject: "me"},
+      {body: "correct", subject: "you"},
+      {body: "wrong 2", subject: "other"},
+    ]);
+    await bot.say("me", "@hubot blarf @you");
+    await bot.waitForResponse("correct");
+  });
+
+  it("can be configured to default to self with no query", async function() {
+    usesDatabase(this);
+
+    await populate({userOriented: true}, [
+      {body: "wrong 1", subject: "you"},
+      {body: "wrong 2", subject: "you"},
+      {body: "correct", subject: "me"},
+      {body: "wrong 3", subject: "other"},
+      {body: "wrong 4", subject: "person-four"},
+    ]);
+    await bot.say("me", "@hubot blarf");
+    await bot.waitForResponse("correct");
+  });
+
+  it("can be configured to return the latest rather than a random result", async function() {
+    usesDatabase(this);
+
+    documentSet = createDocumentSet(bot.getRobot(), "blarf", {
+      query: {userOriented: true, latest: true},
+    });
 
     for (let i = 0; i < 10; i++) {
-      await documentSet.add('me', `document #${i}`, [{ kind: 'subject', value: 'me' }])
+      await documentSet.add("me", `document #${i}`, [
+        {kind: "subject", value: "me"},
+      ]);
     }
-    await documentSet.add('me', 'latest', [{ kind: 'subject', value: 'me' }])
+    await documentSet.add("me", "latest", [{kind: "subject", value: "me"}]);
 
-    await bot.say('me', '@hubot blarf')
-    await bot.waitForResponse('latest')
-  })
+    await bot.say("me", "@hubot blarf");
+    await bot.waitForResponse("latest");
+  });
 
-  it('generates default help text', async function () {
-    await bot.loadHelp()
-    documentSet = createDocumentSet(bot.getRobot(), 'blarf', { query: true })
-    await bot.say('me', '@hubot help blarf')
-    await bot.waitForResponse(/blarf/)
+  it("generates default help text", async function() {
+    await bot.loadHelp();
+    documentSet = createDocumentSet(bot.getRobot(), "blarf", {query: true});
+    await bot.say("me", "@hubot help blarf");
+    await bot.waitForResponse(/blarf/);
 
-    const messages = bot.helpLines()
-    expect(messages).to.include('hubot blarf - Return a blarf at random.')
-    expect(messages).to.include('hubot blarf <query> - Return a blarf that matches <query>.')
-  })
+    const messages = bot.helpLines();
+    expect(messages).to.include("hubot blarf - Return a blarf at random.");
+    expect(messages).to.include(
+      "hubot blarf <query> - Return a blarf that matches <query>."
+    );
+  });
 
-  it('accepts custom help text', async function () {
-    await bot.loadHelp()
-    documentSet = createDocumentSet(bot.getRobot(), 'blarf', {
+  it("accepts custom help text", async function() {
+    await bot.loadHelp();
+    documentSet = createDocumentSet(bot.getRobot(), "blarf", {
       query: {
-        helpText: [
-          'hubot blarf 1 - line one',
-          'hubot blarf 2 - line two'
-        ]
-      }
-    })
-    await bot.say('me', '@hubot help blarf')
-    await bot.waitForResponse(/blarf/)
+        helpText: ["hubot blarf 1 - line one", "hubot blarf 2 - line two"],
+      },
+    });
+    await bot.say("me", "@hubot help blarf");
+    await bot.waitForResponse(/blarf/);
 
-    const messages = bot.helpLines()
-    expect(messages).to.include('hubot blarf 1 - line one')
-    expect(messages).to.include('hubot blarf 2 - line two')
-  })
-})
+    const messages = bot.helpLines();
+    expect(messages).to.include("hubot blarf 1 - line one");
+    expect(messages).to.include("hubot blarf 2 - line two");
+  });
+});

--- a/test/quotes/roles.js
+++ b/test/quotes/roles.js
@@ -1,18 +1,18 @@
 const OnlyMe = {
   verify: (robot, msg) => {
-    if (msg.message.user.name === 'me') {
-      return true
+    if (msg.message.user.name === "me") {
+      return true;
     }
 
-    msg.reply('NOPE')
-    return false
-  }
-}
+    msg.reply("NOPE");
+    return false;
+  },
+};
 
 const Nobody = {
   verify: (robot, msg) => {
-    return false
-  }
-}
+    return false;
+  },
+};
 
-module.exports = { OnlyMe, Nobody }
+module.exports = {OnlyMe, Nobody};

--- a/test/quotes/set.test.js
+++ b/test/quotes/set.test.js
@@ -1,171 +1,183 @@
-const { OnlyMe, Nobody } = require('./roles')
+const {OnlyMe, Nobody} = require("./roles");
 
-const { createDocumentSet } = require('../../scripts/documentset')
+const {createDocumentSet} = require("../../scripts/documentset");
 
-describe('DocumentSet set', function () {
-  let bot, time, documentSet
+describe("DocumentSet set", function() {
+  let bot, time, documentSet;
 
-  beforeEach(function () {
-    bot = new BotContext()
-    time = new TimeContext()
-  })
+  beforeEach(function() {
+    bot = new BotContext();
+    time = new TimeContext();
+  });
 
-  afterEach(function () {
-    bot.destroy()
-    time.destroy()
+  afterEach(function() {
+    bot.destroy();
+    time.destroy();
     if (documentSet) {
-      return documentSet.destroy()
+      return documentSet.destroy();
     }
-  })
+  });
 
-  it('adds a new document with "setblarf:"', async function () {
-    usesDatabase(this)
-    documentSet = createDocumentSet(bot.getRobot(), 'blarf', { set: true })
+  it('adds a new document with "setblarf:"', async function() {
+    usesDatabase(this);
+    documentSet = createDocumentSet(bot.getRobot(), "blarf", {set: true});
 
-    await documentSet.whenConnected()
-    await bot.say('me', '@hubot setblarf: something embarassing')
-    await bot.waitForResponse("me's blarf has been set to 'something embarassing'.")
+    await documentSet.whenConnected();
+    await bot.say("me", "@hubot setblarf: something embarassing");
+    await bot.waitForResponse(
+      "me's blarf has been set to 'something embarassing'."
+    );
 
-    const doc = await documentSet.latestMatching({ subject: ['me'] }, '')
-    expect(doc.getBody()).to.equal('something embarassing')
-  })
+    const doc = await documentSet.latestMatching({subject: ["me"]}, "");
+    expect(doc.getBody()).to.equal("something embarassing");
+  });
 
-  it('adds a new document for a different user with "setblarf @<username>:"', async function () {
-    usesDatabase(this)
-    documentSet = createDocumentSet(bot.getRobot(), 'blarf', { set: true })
+  it('adds a new document for a different user with "setblarf @<username>:"', async function() {
+    usesDatabase(this);
+    documentSet = createDocumentSet(bot.getRobot(), "blarf", {set: true});
 
-    await documentSet.whenConnected()
-    await bot.say('me', '@hubot setblarf @other: something embarassing')
-    await bot.waitForResponse("other's blarf has been set to 'something embarassing'.")
+    await documentSet.whenConnected();
+    await bot.say("me", "@hubot setblarf @other: something embarassing");
+    await bot.waitForResponse(
+      "other's blarf has been set to 'something embarassing'."
+    );
 
-    const doc = await documentSet.latestMatching({ subject: ['other'] }, '')
-    expect(doc.getBody()).to.equal('something embarassing')
-  })
+    const doc = await documentSet.latestMatching({subject: ["other"]}, "");
+    expect(doc.getBody()).to.equal("something embarassing");
+  });
 
-  it('replaces an existing document with "setblarf:"', async function () {
-    usesDatabase(this)
-    documentSet = createDocumentSet(bot.getRobot(), 'blarf', { set: true })
+  it('replaces an existing document with "setblarf:"', async function() {
+    usesDatabase(this);
+    documentSet = createDocumentSet(bot.getRobot(), "blarf", {set: true});
 
-    await documentSet.add('admin', 'blah', [{ kind: 'subject', value: 'me' }])
-    await bot.say('me', '@hubot setblarf: something better')
-    await bot.waitForResponse("me's blarf has been changed from 'blah' to 'something better'.")
-
-    const [count, doc] = await Promise.all([
-      documentSet.countMatching({ subject: ['me'] }, ''),
-      documentSet.latestMatching({ subject: ['me'] }, '')
-    ])
-
-    expect(count).to.equal(2)
-    expect(doc.getBody()).to.equal('something better')
-  })
-
-  it('replaces an existing document for a different user with "setblarf @<username>:"', async function () {
-    usesDatabase(this)
-    documentSet = createDocumentSet(bot.getRobot(), 'blarf', { set: true })
-
-    await documentSet.add('admin', 'blah', [{ kind: 'subject', value: 'other' }])
-
-    await bot.say('me', '@hubot setblarf other: something better')
-    await bot.waitForResponse("other's blarf has been changed from 'blah' to 'something better'.")
+    await documentSet.add("admin", "blah", [{kind: "subject", value: "me"}]);
+    await bot.say("me", "@hubot setblarf: something better");
+    await bot.waitForResponse(
+      "me's blarf has been changed from 'blah' to 'something better'."
+    );
 
     const [count, doc] = await Promise.all([
-      documentSet.countMatching({ subject: ['other'] }, ''),
-      documentSet.latestMatching({ subject: ['other'] }, '')
-    ])
-    expect(count).to.equal(2)
-    expect(doc.getBody()).to.equal('something better')
-  })
+      documentSet.countMatching({subject: ["me"]}, ""),
+      documentSet.latestMatching({subject: ["me"]}, ""),
+    ]);
 
-  it('validates a required role for setting your own', async function () {
-    usesDatabase(this)
-    documentSet = createDocumentSet(bot.getRobot(), 'blarf', {
-      set: { roleForSelf: OnlyMe }
-    })
+    expect(count).to.equal(2);
+    expect(doc.getBody()).to.equal("something better");
+  });
 
-    await documentSet.whenConnected()
+  it('replaces an existing document for a different user with "setblarf @<username>:"', async function() {
+    usesDatabase(this);
+    documentSet = createDocumentSet(bot.getRobot(), "blarf", {set: true});
 
-    await bot.say('you', '@hubot setblarf: nice try')
-    await bot.waitForResponse('@you NOPE')
+    await documentSet.add("admin", "blah", [{kind: "subject", value: "other"}]);
 
-    await bot.say('you', '@hubot setblarf @me: this works')
-    await bot.waitForResponse("me's blarf has been set to 'this works'.")
+    await bot.say("me", "@hubot setblarf other: something better");
+    await bot.waitForResponse(
+      "other's blarf has been changed from 'blah' to 'something better'."
+    );
 
-    const [meCount, youCount] = await Promise.all([
-      documentSet.countMatching({ subject: ['me'] }, ''),
-      documentSet.countMatching({ subject: ['you'] }, '')
-    ])
+    const [count, doc] = await Promise.all([
+      documentSet.countMatching({subject: ["other"]}, ""),
+      documentSet.latestMatching({subject: ["other"]}, ""),
+    ]);
+    expect(count).to.equal(2);
+    expect(doc.getBody()).to.equal("something better");
+  });
 
-    expect(meCount).to.equal(1)
-    expect(youCount).to.equal(0)
-  })
+  it("validates a required role for setting your own", async function() {
+    usesDatabase(this);
+    documentSet = createDocumentSet(bot.getRobot(), "blarf", {
+      set: {roleForSelf: OnlyMe},
+    });
 
-  it('validates a required role for setting another', async function () {
-    usesDatabase(this)
-    documentSet = createDocumentSet(bot.getRobot(), 'blarf', {
-      set: { roleForOther: OnlyMe }
-    })
+    await documentSet.whenConnected();
 
-    await documentSet.whenConnected()
+    await bot.say("you", "@hubot setblarf: nice try");
+    await bot.waitForResponse("@you NOPE");
 
-    await bot.say('you', '@hubot setblarf me: nice try')
-    await bot.waitForResponse('@you NOPE')
-
-    await bot.say('you', '@hubot setblarf: this works')
-    await bot.waitForResponse("you's blarf has been set to 'this works'.")
+    await bot.say("you", "@hubot setblarf @me: this works");
+    await bot.waitForResponse("me's blarf has been set to 'this works'.");
 
     const [meCount, youCount] = await Promise.all([
-      documentSet.countMatching({ subject: ['me'] }, ''),
-      documentSet.countMatching({ subject: ['you'] }, '')
-    ])
+      documentSet.countMatching({subject: ["me"]}, ""),
+      documentSet.countMatching({subject: ["you"]}, ""),
+    ]);
 
-    expect(meCount).to.equal(0)
-    expect(youCount).to.equal(1)
-  })
+    expect(meCount).to.equal(1);
+    expect(youCount).to.equal(0);
+  });
 
-  it('validates the correct role for explicitly setting your own', async function () {
-    usesDatabase(this)
-    documentSet = createDocumentSet(bot.getRobot(), 'blarf', {
-      set: { roleForSelf: OnlyMe, roleForOther: Nobody }
-    })
+  it("validates a required role for setting another", async function() {
+    usesDatabase(this);
+    documentSet = createDocumentSet(bot.getRobot(), "blarf", {
+      set: {roleForOther: OnlyMe},
+    });
 
-    await documentSet.whenConnected()
-    await bot.say('me', '@hubot setblarf me: this works')
-    await bot.waitForResponse("me's blarf has been set to 'this works'.")
+    await documentSet.whenConnected();
 
-    const count = await documentSet.countMatching({ subject: ['me'] }, '')
-    expect(count).to.equal(1)
-  })
+    await bot.say("you", "@hubot setblarf me: nice try");
+    await bot.waitForResponse("@you NOPE");
 
-  it('generates default help text', async function () {
-    usesDatabase(this)
-    await bot.loadHelp()
-    documentSet = createDocumentSet(bot.getRobot(), 'blarf', { set: true })
+    await bot.say("you", "@hubot setblarf: this works");
+    await bot.waitForResponse("you's blarf has been set to 'this works'.");
 
-    await bot.say('me', '@hubot help')
-    await bot.waitForResponse(/hubot setblarf/)
-    const messages = bot.helpLines()
+    const [meCount, youCount] = await Promise.all([
+      documentSet.countMatching({subject: ["me"]}, ""),
+      documentSet.countMatching({subject: ["you"]}, ""),
+    ]);
 
-    expect(messages).to.include("hubot setblarf <user>: <source> - Set user's blarf to <source>.")
-    expect(messages).to.include('hubot setblarf: <source> - Set your own blarf to <source>.')
-  })
+    expect(meCount).to.equal(0);
+    expect(youCount).to.equal(1);
+  });
 
-  it('accepts custom help text', async function () {
-    usesDatabase(this)
-    await bot.loadHelp()
-    documentSet = createDocumentSet(bot.getRobot(), 'blarf', {
+  it("validates the correct role for explicitly setting your own", async function() {
+    usesDatabase(this);
+    documentSet = createDocumentSet(bot.getRobot(), "blarf", {
+      set: {roleForSelf: OnlyMe, roleForOther: Nobody},
+    });
+
+    await documentSet.whenConnected();
+    await bot.say("me", "@hubot setblarf me: this works");
+    await bot.waitForResponse("me's blarf has been set to 'this works'.");
+
+    const count = await documentSet.countMatching({subject: ["me"]}, "");
+    expect(count).to.equal(1);
+  });
+
+  it("generates default help text", async function() {
+    usesDatabase(this);
+    await bot.loadHelp();
+    documentSet = createDocumentSet(bot.getRobot(), "blarf", {set: true});
+
+    await bot.say("me", "@hubot help");
+    await bot.waitForResponse(/hubot setblarf/);
+    const messages = bot.helpLines();
+
+    expect(messages).to.include(
+      "hubot setblarf <user>: <source> - Set user's blarf to <source>."
+    );
+    expect(messages).to.include(
+      "hubot setblarf: <source> - Set your own blarf to <source>."
+    );
+  });
+
+  it("accepts custom help text", async function() {
+    usesDatabase(this);
+    await bot.loadHelp();
+    documentSet = createDocumentSet(bot.getRobot(), "blarf", {
       set: {
         helpText: [
-          'hubot setblarf 1 - First line',
-          'hubot setblarf 2 - Second line'
-        ]
-      }
-    })
+          "hubot setblarf 1 - First line",
+          "hubot setblarf 2 - Second line",
+        ],
+      },
+    });
 
-    await bot.say('me', '@hubot help setblarf')
-    await bot.waitForResponse(/setblarf 1/)
-    const messages = bot.helpLines()
+    await bot.say("me", "@hubot help setblarf");
+    await bot.waitForResponse(/setblarf 1/);
+    const messages = bot.helpLines();
 
-    expect(messages).to.include('hubot setblarf 1 - First line')
-    expect(messages).to.include('hubot setblarf 2 - Second line')
-  })
-})
+    expect(messages).to.include("hubot setblarf 1 - First line");
+    expect(messages).to.include("hubot setblarf 2 - Second line");
+  });
+});

--- a/test/quotes/stats.test.js
+++ b/test/quotes/stats.test.js
@@ -1,100 +1,118 @@
-const { createDocumentSet } = require('../../scripts/documentset')
+const {createDocumentSet} = require("../../scripts/documentset");
 
-describe('DocumentSet stats', function () {
-  let bot, documentSet
+describe("DocumentSet stats", function() {
+  let bot, documentSet;
 
-  beforeEach(function () {
-    bot = new BotContext()
-  })
+  beforeEach(function() {
+    bot = new BotContext();
+  });
 
-  afterEach(function () {
-    bot.destroy()
+  afterEach(function() {
+    bot.destroy();
     if (documentSet) {
-      return documentSet.destroy()
+      return documentSet.destroy();
     }
-  })
+  });
 
-  function populate (commandOpts, docs) {
-    documentSet = createDocumentSet(bot.getRobot(), 'blarf', {
-      stats: commandOpts
-    })
+  function populate(commandOpts, docs) {
+    documentSet = createDocumentSet(bot.getRobot(), "blarf", {
+      stats: commandOpts,
+    });
 
-    return Promise.all(docs.map(doc => {
-      const attributes = []
-      for (const kind in doc.attrs) {
-        for (const value of doc.attrs[kind]) {
-          attributes.push({ kind, value })
+    return Promise.all(
+      docs.map(doc => {
+        const attributes = [];
+        for (const kind in doc.attrs) {
+          for (const value of doc.attrs[kind]) {
+            attributes.push({kind, value});
+          }
         }
-      }
 
-      return documentSet.add('me', doc.body, attributes)
-    }))
+        return documentSet.add("me", doc.body, attributes);
+      })
+    );
   }
 
-  it('summarizes all known speaker and mention credits', async function () {
-    usesDatabase(this)
+  it("summarizes all known speaker and mention credits", async function() {
+    usesDatabase(this);
     await populate(true, [
-      { body: '0', attrs: { speaker: ['person-one', 'person-two'], mention: ['person-two'] } },
-      { body: '1', attrs: { speaker: ['person-one'], mention: ['person-three'] } },
-      { body: '2', attrs: { speaker: ['person-two'], mention: ['person-one', 'person-two'] } },
-      { body: '3', attrs: { speaker: ['person-one'], mention: ['person-three'] } }
-    ])
+      {
+        body: "0",
+        attrs: {speaker: ["person-one", "person-two"], mention: ["person-two"]},
+      },
+      {body: "1", attrs: {speaker: ["person-one"], mention: ["person-three"]}},
+      {
+        body: "2",
+        attrs: {speaker: ["person-two"], mention: ["person-one", "person-two"]},
+      },
+      {body: "3", attrs: {speaker: ["person-one"], mention: ["person-three"]}},
+    ]);
 
-    await bot.say('me', '@hubot blarfstats')
-    const expected = '```\n' +
-      'Username     | Spoke | Mentioned\n' +
-      '--------------------------------\n' +
-      'person-one   | 3     | 1\n' +
-      'person-two   | 2     | 2\n' +
-      'person-three | 0     | 2\n' +
-      '```\n'
-    await bot.waitForResponse(expected)
-  })
+    await bot.say("me", "@hubot blarfstats");
+    const expected =
+      "```\n" +
+      "Username     | Spoke | Mentioned\n" +
+      "--------------------------------\n" +
+      "person-one   | 3     | 1\n" +
+      "person-two   | 2     | 2\n" +
+      "person-three | 0     | 2\n" +
+      "```\n";
+    await bot.waitForResponse(expected);
+  });
 
-  it("summarizes a user's speaker and mention counts", async function () {
-    usesDatabase(this)
+  it("summarizes a user's speaker and mention counts", async function() {
+    usesDatabase(this);
     await populate(true, [
-      { body: '0', attrs: { speaker: ['person-one'], mention: ['person-two'] } },
-      { body: '1', attrs: { speaker: ['person-one'], mention: ['person-three'] } },
-      { body: '2', attrs: { speaker: ['person-two'], mention: ['person-one', 'person-two'] } },
-      { body: '3', attrs: { speaker: ['person-one'], mention: [] } }
-    ])
+      {body: "0", attrs: {speaker: ["person-one"], mention: ["person-two"]}},
+      {body: "1", attrs: {speaker: ["person-one"], mention: ["person-three"]}},
+      {
+        body: "2",
+        attrs: {speaker: ["person-two"], mention: ["person-one", "person-two"]},
+      },
+      {body: "3", attrs: {speaker: ["person-one"], mention: []}},
+    ]);
 
-    await bot.say('me', '@hubot blarfstats @person-two')
-    await bot.waitForResponse('person-two is *#2*, having spoken in *1* blarf and being mentioned in *2*.')
-  })
+    await bot.say("me", "@hubot blarfstats @person-two");
+    await bot.waitForResponse(
+      "person-two is *#2*, having spoken in *1* blarf and being mentioned in *2*."
+    );
+  });
 
-  it('generates default help text', async function () {
-    usesDatabase(this)
+  it("generates default help text", async function() {
+    usesDatabase(this);
 
-    await bot.loadHelp()
-    documentSet = createDocumentSet(bot.getRobot(), 'blarf', { stats: true })
+    await bot.loadHelp();
+    documentSet = createDocumentSet(bot.getRobot(), "blarf", {stats: true});
 
-    await bot.say('me', '@hubot help blarfstats')
-    await bot.waitForResponse(/blarfstats/)
+    await bot.say("me", "@hubot help blarfstats");
+    await bot.waitForResponse(/blarfstats/);
 
-    const messages = bot.helpLines()
-    expect(messages).to.include('hubot blarfstats - See who has the most blarfs.')
-    expect(messages).to.include('hubot blarfstats <user> - See the number of blarfs attributed to <user>.')
-  })
+    const messages = bot.helpLines();
+    expect(messages).to.include(
+      "hubot blarfstats - See who has the most blarfs."
+    );
+    expect(messages).to.include(
+      "hubot blarfstats <user> - See the number of blarfs attributed to <user>."
+    );
+  });
 
-  it('accepts custom help text', async function () {
-    usesDatabase(this)
+  it("accepts custom help text", async function() {
+    usesDatabase(this);
 
-    await bot.loadHelp()
-    documentSet = createDocumentSet(bot.getRobot(), 'blarf', {
+    await bot.loadHelp();
+    documentSet = createDocumentSet(bot.getRobot(), "blarf", {
       stats: {
         helpText: [
-          'hubot blarfstats 1 - First line',
-          'hubot blarfstats 2 - Second line'
-        ]
-      }
-    })
-    await bot.say('me', '@hubot help blarfstats')
-    await bot.waitForResponse(/blarfstats/)
+          "hubot blarfstats 1 - First line",
+          "hubot blarfstats 2 - Second line",
+        ],
+      },
+    });
+    await bot.say("me", "@hubot help blarfstats");
+    await bot.waitForResponse(/blarfstats/);
 
-    const messages = bot.helpLines()
-    expect(messages).to.include('hubot blarfstats 1 - First line')
-    expect(messages).to.include('hubot blarfstats 2 - Second line')
-  })
-})
+    const messages = bot.helpLines();
+    expect(messages).to.include("hubot blarfstats 1 - First line");
+    expect(messages).to.include("hubot blarfstats 2 - Second line");
+  });
+});


### PR DESCRIPTION
Add support for `!rem` key-value pairs in the GraphQL API.

- [x] Get a single key
- [x] Search a paginated collection of keys, optionally matching a substring query
- [x] Search order: creation order, lexicographic by key, random
